### PR TITLE
fingers-pattern-N settings with N > 9 were ignored

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -41,7 +41,7 @@ else
 fi
 
 IFS=$'\n'
-USER_DEFINED_PATTERNS=($(tmux show-options -g | grep ^@fingers-pattern | sed 's/^@fingers-pattern-[0-9] "\(.*\)"$/(\1)/'))
+USER_DEFINED_PATTERNS=($(tmux show-options -g | sed -n 's/^@fingers-pattern-[0-9]\{1,\} "\(.*\)"$/(\1)/p'))
 unset IFS
 
 PATTERNS_LIST=("${PATTERNS_LIST[@]}" "${USER_DEFINED_PATTERNS[@]}")


### PR DESCRIPTION
This patch fixes the regular expression that parses `fingers-pattern-N`
settings, allowing the `N` number to contain either one or more digits.

Before this patch:

    $ (echo '@fingers-pattern-0 "git rebase --(abort|continue)"'; echo '@fingers-pattern-1 "yolo"'; echo '@fingers-pattern-50 "whatever"') | grep '^@fingers-pattern' | sed 's/^@fingers-pattern-[0-9] "\(.*\)"$/(\1)/'
    (git rebase --(abort|continue))
    (yolo)
    @fingers-pattern-50 "whatever"

After this patch:

    $ (echo '@fingers-pattern-0 "git rebase --(abort|continue)"'; echo '@fingers-pattern-1 "yolo"'; echo '@fingers-pattern-50 "whatever"') | sed -n 's/^@fingers-pattern-[0-9]\{1,\} "\(.*\)"$/(\1)/p'
    (git rebase --(abort|continue))
    (yolo)
    (whatever)