### PR TITLE
support variable length sha1 commit ids

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -26,7 +26,7 @@ if [[ $(supports_intervals_in_awk) == "1" ]]; then
   PATTERNS_LIST=(
   "((^|^\.|[[:space:]]|[[:space:]]\.|[[:space:]]\.\.|^\.\.)[[:alnum:]~_-]*/[][[:alnum:]_.#$%&+=/@-]+)"
   "([[:digit:]]{4,})"
-  "([0-9a-f]{7}|[0-9a-f]{40})"
+  "([0-9a-f]{7,40})"
   "((https?://|git@|git://|ssh://|ftp://|file:///)[[:alnum:]?=%/_.:,;~@!#$&()*+-]*)"
   "([[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3})"
   )


### PR DESCRIPTION
The sha1 commit ids displayed by git may range in size and are not strictly 7 digits or 40 digits. In practice, the old default was something like 7, and that was enough to uniquely distinguish the commit. However, some repositories (Upstream Linux kernel) now use 12 as the default.

When we support intervals, use them to specify the full range to make the hint grab all available characters.