### PR TITLE
System health check ( making gawk a hard dependency )

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ While in **[fingers]** mode, you can use the following shortcuts:
 
 # Requirements
 
-* bash 4+
 * tmux 2.1+ ( 2.2 recommended )
-* gawk ( optional but recommended )
+* bash 4+
+* gawk
 
 # Installation
 

--- a/docs/health-check.md
+++ b/docs/health-check.md
@@ -26,3 +26,11 @@ This probably means you are running OSX, which ships with *bash 3*. In order to 
 ## tmux version is too old
 
 You can install latest *tmux* from source, check https://github.com/tmux/tmux
+
+## How to skip the check
+
+If can't skip this check by adding the following in your .tmux.conf file:
+
+```
+set -g @fingers-skip-health-check '1'
+```

--- a/docs/health-check.md
+++ b/docs/health-check.md
@@ -1,0 +1,28 @@
+# Health check troubleshooting
+
+*tmux-fingers* performs a health check on startup to ensure that your system has all dependencies needed to run smoothly.
+
+They are not much, and in most GNU/linux environments these are the defaults anyway.
+
+## gawk not found
+
+Install `gawk` package.
+
+### OSX
+
+`$ brew install gawk`
+
+### Linux
+
+* Ubuntu: `$ sudo aptitude install gawk`
+* Arch linux: `$ sudo pacman -S install gawk`
+
+## bash version is too old
+
+This probably means you are running OSX, which ships with *bash 3*. In order to upgrade to *bash 4* you need need to run:
+
+`$ brew install bash`
+
+## tmux version is too old
+
+You can install latest *tmux* from source, check https://github.com/tmux/tmux

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -14,31 +14,15 @@ function check_pattern() {
   fi
 }
 
-HAS_GAWK=$(which gawk &> /dev/null && echo $(($? == 0)))
-
-function supports_intervals_in_awk() {
-  echo "wtfwtfwtf" | __awk__ "/(wtf){3}/ { print \"wtf\" }" | grep -c wtf
-}
-
 source "$CURRENT_DIR/utils.sh"
 
-if [[ $(supports_intervals_in_awk) == "1" ]]; then
-  PATTERNS_LIST=(
-  "((^|^\.|[[:space:]]|[[:space:]]\.|[[:space:]]\.\.|^\.\.)[[:alnum:]~_-]*/[][[:alnum:]_.#$%&+=/@-]+)"
-  "([[:digit:]]{4,})"
-  "([0-9a-f]{7,40})"
-  "((https?://|git@|git://|ssh://|ftp://|file:///)[[:alnum:]?=%/_.:,;~@!#$&()*+-]*)"
-  "([[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3})"
-  )
-else
-  PATTERNS_LIST=(
-  "((^|^\.|[[:space:]]|[[:space:]]\.|[[:space:]]\.\.|^\.\.)[[:alnum:]~_-]*/[][[:alnum:]_.#$%&+=/@-]+)"
-  "([[:digit:]][[:digit:]][[:digit:]][[:digit:]]([[:digit:]])*)"
-  "([0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]|[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])"
-  "((https?://|git@|git://|ssh://|ftp://|file:///)[[:alnum:]?=%/_.:,;~@!#$&()*+-]*)"
-  "([[:digit:]][[:digit:]]?[[:digit:]]?\.[[:digit:]][[:digit:]]?[[:digit:]]?\.[[:digit:]][[:digit:]]?[[:digit:]]?\.[[:digit:]][[:digit:]]?[[:digit:]]?)"
-  )
-fi
+PATTERNS_LIST=(
+"((^|^\.|[[:space:]]|[[:space:]]\.|[[:space:]]\.\.|^\.\.)[[:alnum:]~_-]*/[][[:alnum:]_.#$%&+=/@-]+)"
+"([[:digit:]]{4,})"
+"([0-9a-f]{7,40})"
+"((https?://|git@|git://|ssh://|ftp://|file:///)[[:alnum:]?=%/_.:,;~@!#$&()*+-]*)"
+"([[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3})"
+)
 
 IFS=$'\n'
 USER_DEFINED_PATTERNS=($(tmux show-options -g | sed -n 's/^@fingers-pattern-[0-9]\{1,\} "\(.*\)"$/(\1)/p'))

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -68,7 +68,9 @@ function perform_health_check() {
       : # waiting for-tmux
     done
 
-    tmux run "echo -e 'tmux-fingers health-check:\\n\\n'; cat $health_tmp"
+    log_health "For more info check $HELP_LINK"
+    log_health "To skip this check add \"set -g @fingers-skip-health-check 1\" to your tmux conf"
+    tmux run "echo -e \"tmux-fingers health-check:\"; cat $health_tmp"
   fi
 
   rm -rf "$health_tmp"

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -2,7 +2,6 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $CURRENT_DIR/utils.sh
-source $CURRENT_DIR/debug.sh
 
 REQUIRED_BASH_MAJOR=4
 REQUIRED_TMUX_MAJOR=2
@@ -10,6 +9,7 @@ RECOMMENDED_TMUX_MINOR=3
 HELP_LINK="https://github.com/Morantron/tmux-fingers/blob/master/docs/health-check.md"
 
 health_tmp=$(fingers_tmp)
+log_messages=()
 
 function is_tmux_ready() {
   local num_windows=$(tmux list-windows | wc -l)
@@ -31,22 +31,88 @@ function program_exists() {
   fi
 }
 
-function log_health() {
-  echo "$1" >> "$health_tmp"
+function log_message() {
+  log_messages+=("$1")
+}
+
+function repeat_char() {
+  local char="$1"
+  local n_times="$2"
+  local i=0
+  local output=""
+
+  while [[ $i -lt "$n_times" ]]; do
+    output="$output$char"
+    i=$((i + 1))
+  done
+
+  echo "$output"
+}
+
+function right_pad() {
+  local str="$1"
+  local char="$2"
+  local max_length="$3"
+  local padding=$(($max_length - ${#str}))
+
+  if [[ padding -lt 0 ]]; then
+    padding=0
+  fi
+
+  echo "$str$(repeat_char "$char" "$padding")"
+}
+
+function dump_log() {
+  log_messages=("tmux-fingers health-check:" "" "${log_messages[@]}")
+
+  # pad messages
+  local i=0
+  for message in "${log_messages[@]}" ; do
+    log_messages[$i]=" $message "
+    i=$((i + 1))
+  done
+
+  # calculate max_length
+  local lengths=""
+  for message in "${log_messages[@]}" ; do
+    lengths="$lengths\n${#message}"
+  done
+  local max_length=$(echo -e "$lengths" | sort -r | head -n 1)
+
+  local horizontal_border="+$(repeat_char "-" $((max_length)))+"
+
+  # wrap messages within pipe chars
+  i=0
+  for message in "${log_messages[@]}" ; do
+    log_messages[$i]="|$(right_pad "$message" " " $((max_length)))|"
+    i=$((i + 1))
+  done
+
+  log_messages=($horizontal_border "${log_messages[@]}" $horizontal_border)
+
+  for message in "${log_messages[@]}" ; do
+    echo -e "$message" >> "$health_tmp"
+  done
 }
 
 function perform_health_check() {
   local healthy=1
 
+  FINGERS_SKIP_HEALTH_CHECK=$(tmux show-option -gqv @fingers-skip-health-check)
+
+  if [[ $FINGERS_SKIP_HEALTH_CHECK -eq 1 ]]; then
+    return
+  fi
+
   if [[ $(program_exists "gawk") = "0" ]]; then
-    log_health "* 'gawk' not found"
+    log_message "* 'gawk' not found"
     healthy=0
   fi
 
   BASH_MAJOR=$(echo "$BASH_VERSION" | grep -Eo "^[0-9]")
 
   if [[ "$BASH_MAJOR" -lt "$REQUIRED_BASH_MAJOR" ]]; then
-    log_health "* Bash version \"$BASH_VERSION\" is too old."
+    log_message "  * Bash version \"$BASH_VERSION\" is too old."
     healthy=0
   fi
 
@@ -55,12 +121,12 @@ function perform_health_check() {
   TMUX_MINOR=$(echo "$TMUX_VERSION" | cut -f2 -d. | grep -Eo "[0-9]")
 
   if [[ $TMUX_MAJOR -lt $REQUIRED_TMUX_MAJOR ]]; then
-    log_health "* tmux version \"$TMUX_VERSION\" is too old."
+    log_message "  * tmux version \"$TMUX_VERSION\" is too old."
     healthy=0
   fi
 
   if [[ $TMUX_MAJOR -eq $REQUIRED_TMUX_MAJOR ]] && [[ $TMUX_MINOR -lt $RECOMMENDED_TMUX_MINOR ]]; then
-    echo "* WARNING: tmux 2.2+ is recommended"
+    echo "  * WARNING: tmux 2.2+ is recommended"
   fi
 
   if [[ $healthy -eq 0 ]]; then
@@ -68,9 +134,18 @@ function perform_health_check() {
       : # waiting for-tmux
     done
 
-    log_health "For more info check $HELP_LINK"
-    log_health "To skip this check add \"set -g @fingers-skip-health-check 1\" to your tmux conf"
-    tmux run "echo -e \"tmux-fingers health-check:\"; cat $health_tmp"
+    log_message ""
+    log_message "For a better tmux-fingers experience, please install the required versions."
+    log_message ""
+    log_message "For more info check:"
+    log_message "  $HELP_LINK"
+    log_message ""
+    log_message "To skip this check add \"set -g @fingers-skip-health-check '1'\" to your tmux conf"
+    log_message ""
+
+    dump_log
+
+    tmux run "cat $health_tmp"
   fi
 
   rm -rf "$health_tmp"

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $CURRENT_DIR/utils.sh
+source $CURRENT_DIR/debug.sh
+
+REQUIRED_BASH_MAJOR=4
+REQUIRED_TMUX_MAJOR=2
+RECOMMENDED_TMUX_MINOR=3
+HELP_LINK="https://github.com/Morantron/tmux-fingers/blob/master/docs/health-check.md"
+
+health_tmp=$(fingers_tmp)
+
+function is_tmux_ready() {
+  local num_windows=$(tmux list-windows | wc -l)
+
+  if [[ $num_windows -gt 0 ]]; then
+    echo 1
+  else
+    echo 0
+  fi
+}
+
+function program_exists() {
+  local prog="$1"
+
+  if [[ $(which "$prog" &> /dev/null) ]]; then
+    echo "0"
+  else
+    echo "1"
+  fi
+}
+
+function log_health() {
+  echo "$1" >> "$health_tmp"
+}
+
+function perform_health_check() {
+  local healthy=1
+
+  if [[ $(program_exists "gawk") = "0" ]]; then
+    log_health "* 'gawk' not found"
+    healthy=0
+  fi
+
+  BASH_MAJOR=$(echo "$BASH_VERSION" | grep -Eo "^[0-9]")
+
+  if [[ "$BASH_MAJOR" -lt "$REQUIRED_BASH_MAJOR" ]]; then
+    log_health "* Bash version \"$BASH_VERSION\" is too old."
+    healthy=0
+  fi
+
+  TMUX_VERSION=$(tmux -V | grep -Eio "[0-9]+(\.[0-9a-z])*$")
+  TMUX_MAJOR=$(echo "$TMUX_VERSION" | cut -f1 -d.)
+  TMUX_MINOR=$(echo "$TMUX_VERSION" | cut -f2 -d. | grep -Eo "[0-9]")
+
+  if [[ $TMUX_MAJOR -lt $REQUIRED_TMUX_MAJOR ]]; then
+    log_health "* tmux version \"$TMUX_VERSION\" is too old."
+    healthy=0
+  fi
+
+  if [[ $TMUX_MAJOR -eq $REQUIRED_TMUX_MAJOR ]] && [[ $TMUX_MINOR -lt $RECOMMENDED_TMUX_MINOR ]]; then
+    echo "* WARNING: tmux 2.2+ is recommended"
+  fi
+
+  if [[ $healthy -eq 0 ]]; then
+    while [[ $(is_tmux_ready) = 0 ]]; do
+      : # waiting for-tmux
+    done
+
+    tmux run "echo -e 'tmux-fingers health-check:\\n\\n'; cat $health_tmp"
+  fi
+
+  rm -rf "$health_tmp"
+}
+
+perform_health_check

--- a/scripts/hints.sh
+++ b/scripts/hints.sh
@@ -30,7 +30,7 @@ function show_hints() {
   local compact_hints=$2
 
   clear_screen "$fingers_pane_id"
-  get_stdin | COMPACT_HINTS=$compact_hints FINGER_PATTERNS=$PATTERNS __awk__ -f $CURRENT_DIR/hinter.awk 3> $match_lookup_table
+  get_stdin | COMPACT_HINTS=$compact_hints FINGER_PATTERNS=$PATTERNS gawk -f $CURRENT_DIR/hinter.awk 3> $match_lookup_table
 }
 
 function show_hints_and_swap() {

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -87,14 +87,6 @@ function fingers_tmp() {
   echo "$tmp_path"
 }
 
-function __awk__() {
-  if hash gawk 2>/dev/null; then
-    gawk "$@"
-  else
-    awk "$@"
-  fi
-}
-
 function clear_screen() {
   local fingers_pane_id=$1
   clear

--- a/test/provisioning/bsd.sh
+++ b/test/provisioning/bsd.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-pkg install -y bash tmux expect fish
+pkg install -y bash tmux expect fish gawk
 chsh -s bash vagrant
 
 echo "fishman" | pw user add -n fishman -h 0 -s "/usr/local/bin/fish"

--- a/tmux-fingers.tmux
+++ b/tmux-fingers.tmux
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 DEFAULT_FINGERS_KEY="F"
 FINGERS_KEY=$(tmux show-option -gqv @fingers-key)
 FINGERS_KEY=${FINGERS_KEY:-$DEFAULT_FINGERS_KEY}
 
+tmux run -b "$CURRENT_DIR/scripts/health-check.sh"
 tmux bind-key $FINGERS_KEY run-shell "tmux capture-pane -p | $CURRENT_DIR/scripts/tmux-fingers.sh"


### PR DESCRIPTION
Supporting multiple versions of awk is tricky, so after this PR is merged *gawk* must be installed by default.

Also, since sometimes there are issues with the system dependencies required to run this plugin ( bash 4, now gawk, and a relatively new version of tmux ), a system health check ( similar to neovim's `:CheckHealth ) will be performed on startup with some links to documentation.

TODO

- [ ] be less annoying, offer a way to bypass the check