### PR TITLE
Extend regular expressions to appease BSD sed

### DIFF
--- a/scripts/fingers.sh
+++ b/scripts/fingers.sh
@@ -10,7 +10,7 @@ source $CURRENT_DIR/help.sh
 
 FINGERS_COPY_COMMAND=$(tmux show-option -gqv @fingers-copy-command)
 HAS_TMUX_YANK=$([ "$(tmux list-keys | grep -c tmux-yank)" == "0" ]; echo $?)
-tmux_yank_copy_command=$(tmux_list_vi_copy_keys | grep -E "(vi-copy|copy-mode-vi) *y" | sed 's/.*copy-pipe\(-and-cancel\)\? *"\(.*\)".*/\2/g')
+tmux_yank_copy_command=$(tmux_list_vi_copy_keys | grep -E "(vi-copy|copy-mode-vi) *y" | sed -E 's/.*copy-pipe(-and-cancel)? *"(.*)".*/\2/g')
 
 current_pane_id=$1
 fingers_pane_id=$2


### PR DESCRIPTION
BSD sed with only basic regular expressions did not like the `\?`. Use extended regular expressions and simplify the regex escaping. Works with both BSD & GNU sed.

## Test Plan

Manually try the new command with both BSD sed & GNU sed.