### PR TITLE
[WHY] Fix silent yank error on macOS

### DIFF
--- a/scripts/fingers.sh
+++ b/scripts/fingers.sh
@@ -103,7 +103,7 @@ function copy_result() {
   fi
 
   if [[ $HAS_TMUX_YANK = 1 ]]; then
-    echo -n "$result" | eval "nohup $tmux_yank_copy_command" > /dev/null
+    echo -n "$result" | eval "$tmux_yank_copy_command" > /dev/null
   fi
 }
 


### PR DESCRIPTION
My `$tmux_yank_copy_command` is `reattach-to-user-namespace pbcopy`. Running it myself in `nohup` is fine. However, tmux-fingers running it with `nohup` produces a silent error: `nohup: can't detach from console: Inappropriate ioctl for device`. Removing `nohup` restores my yank ability.

Why does this work? Is this really the solution?

## Open Issues

* Why is `nohup` okay in 1 situation but not the other?
* Why was `nohup` necessary? `nohup`'s use seems to be carried over from c267108e's `$FINGERS_COPY_COMMAND` fix. The commit doesn't say why.
    * Can the same be done without `nohup`?
* Should tmux-fingers be silencing errors?