### PR TITLE
Multiple Custom Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ While in **[fingers]** mode, you can use the following shortcuts:
 * `<space>`: toggle compact hints ( see [@fingers-compact-hints](#fingers-compact-hints) ).
 * `<Ctrl-C>`: exit **[fingers]** mode
 * `<esc>`: exit help or **[fingers]** mode
+* `C`: change command to execute
 * `?`: show help.
 
 # Requirements
@@ -82,6 +83,8 @@ NOTE: for changes to take effect, you'll need to source again your `.tmux.conf` 
 
 * [@fingers-key](#fingers-key)
 * [@fingers-patterns-N](#fingers-patterns-N)
+* [@fingers-commands](#fingers-commands)
+* [@fingers-default-command](#fingers-default-command)
 * [@fingers-copy-command](#fingers-copy-command)
 * [@fingers-compact-hints](#fingers-compact-hints)
 * [@fingers-hint-position](#fingers-hint-position)
@@ -122,8 +125,30 @@ Patterns are case insensitive, and grep's extended syntax ( ERE ) should be used
 If the introduced regexp contains an error, an error will be shown when
 invoking the plugin.
 
+## @fingers-commands
+
+By default **tmux-fingers** will just yank matches to tmux buffer (or do a custom yank command, see [@fingers-copy-command](#fingers-copy-command)).
+
+To add more commands you can:
+
+```
+set -g @fingers-commands 'OPEN|xargs open;EDIT|xargs tmux new-window vim'
+```
+This will add the command "OPEN" and "EDIT" to the default "YANK" command. To control the style of the status line when a command is chosen, add another "|" with the style like this:
+
+```
+set -g @fingers-commands 'OPEN|xargs open|fg=black,bg=red;EDIT|xargs tmux new-window vim|fg=black,bg=white'
+```
+
+## @fingers-default-command
+
+`default: 0`
+
+The default command to use when starting fingers. The value "0" will always be the built-it "YANK" command. See [@fingers-commands](#fingers-commands) for more details.
+
 ## @fingers-copy-command
 
+The command to execute when applying the default "YANK" command.
 By default **tmux-fingers** will just yank matches using tmux clipboard ( or
 [tmux-yank](https://github.com/tmux-plugins/tmux-yank) if present ).
 

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -51,7 +51,7 @@ function strip_format () {
 }
 
 PATTERNS_LIST=(
-"((^|^\.|[[:space:]]|[[:space:]]\.|[[:space:]]\.\.|^\.\.)[[:alnum:]~_-]*/[][[:alnum:]_.#$%&+=/@-]+)"
+"((^|^\.|[[:space:]\']|[[:space:]]\.|[[:space:]]\.\.|^\.\.)[[:alnum:]~_-]*/[][[:alnum:]_.#$%&+=/@-]+)"
 "([[:digit:]]{4,})"
 "([0-9a-f]{7,40})"
 "((https?://|git@|git://|ssh://|ftp://|file:///)[[:alnum:]?=%/_.:,;~@!#$&()*+-]*)"

--- a/scripts/hints.sh
+++ b/scripts/hints.sh
@@ -37,6 +37,6 @@ function show_hints_and_swap() {
   current_pane_id=$1
   fingers_pane_id=$2
   compact_state=$3
-  show_hints "$fingers_pane_id" $compact_state
   tmux swap-pane -s "$current_pane_id" -t "$fingers_pane_id"
+  show_hints "$fingers_pane_id" $compact_state
 }


### PR DESCRIPTION
Allow customizing multiple addition commands.
toggle chosen command with "C" when in the fingers pane.
Allow user to control the name of the command, the command to execute, and the style of how the chosen command in displayed.

This is my settings, for example:
```
set -g @fingers-commands "OPEN|xargs open|fg=white,bg=red;EDIT|xargs tmux new-window vim"
```