### PR TITLE
Fix fingers pane diplay if pane not zoomed

### DIFF
--- a/scripts/fingers.sh
+++ b/scripts/fingers.sh
@@ -77,7 +77,7 @@ help_state=0
 
 force_dim_support
 pane_was_zoomed=$(is_pane_zoomed "$current_pane_id")
-show_hints_and_swap $current_pane_id $fingers_pane_id $compact_state
+show_hints_and_swap $current_pane_id $fingers_pane_id $compact_state $pane_was_zoomed
 [[ $pane_was_zoomed == "1" ]] && zoom_pane "$fingers_pane_id"
 
 hide_cursor

--- a/scripts/hints.sh
+++ b/scripts/hints.sh
@@ -37,6 +37,13 @@ function show_hints_and_swap() {
   current_pane_id=$1
   fingers_pane_id=$2
   compact_state=$3
-  show_hints "$fingers_pane_id" $compact_state
-  tmux swap-pane -s "$current_pane_id" -t "$fingers_pane_id"
+  pane_was_zoomed=$4
+
+  if [[ $pane_was_zoomed == 1 ]]; then
+    show_hints "$fingers_pane_id" $compact_state
+    tmux swap-pane -s "$current_pane_id" -t "$fingers_pane_id"
+  else
+    tmux swap-pane -s "$current_pane_id" -t "$fingers_pane_id"
+    show_hints "$fingers_pane_id" $compact_state
+  fi
 }


### PR DESCRIPTION
Please see the issue https://github.com/Morantron/tmux-fingers/issues/44

Fix fingers to properly display it's output if current pane located in splitted window.