### PR TITLE
Support kubernetes resources

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -56,6 +56,7 @@ PATTERNS_LIST=(
 "([0-9a-f]{7,40})"
 "((https?://|git@|git://|ssh://|ftp://|file:///)[[:alnum:]?=%/_.:,;~@!#$&()*+-]*)"
 "([[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3})"
+"(deployment.app|binding|componentstatuse|configmap|endpoint|event|limitrange|namespace|node|persistentvolumeclaim|persistentvolume|pod|podtemplate|replicationcontroller|resourcequota|secret|serviceaccount|service|mutatingwebhookconfiguration.admissionregistration.k8s.io|validatingwebhookconfiguration.admissionregistration.k8s.io|customresourcedefinition.apiextension.k8s.io|apiservice.apiregistration.k8s.io|controllerrevision.apps|daemonset.apps|deployment.apps|replicaset.apps|statefulset.apps|tokenreview.authentication.k8s.io|localsubjectaccessreview.authorization.k8s.io|selfsubjectaccessreviews.authorization.k8s.io|selfsubjectrulesreview.authorization.k8s.io|subjectaccessreview.authorization.k8s.io|horizontalpodautoscaler.autoscaling|cronjob.batch|job.batch|certificatesigningrequest.certificates.k8s.io|events.events.k8s.io|daemonset.extensions|deployment.extensions|ingress.extensions|networkpolicies.extensions|podsecuritypolicies.extensions|replicaset.extensions|networkpolicie.networking.k8s.io|poddisruptionbudget.policy|clusterrolebinding.rbac.authorization.k8s.io|clusterrole.rbac.authorization.k8s.io|rolebinding.rbac.authorization.k8s.io|role.rbac.authorization.k8s.io|storageclasse.storage.k8s.io)[[:alnum:]_#$%&+=/@-]+"
 )
 
 IFS=$'\n'

--- a/scripts/hinter.awk
+++ b/scripts/hinter.awk
@@ -102,8 +102,8 @@ BEGIN {
   HINTS[98] = "as"
   HINTS[99] = "aa"
 
-  finger_patterns = ENVIRON["FINGERS_PATTERNS"];
-  fingers_compact_hints = ENVIRON["FINGERS_COMPACT_HINTS"];
+  finger_patterns         = ENVIRON["FINGERS_PATTERNS"];
+  fingers_compact_hints   = ENVIRON["FINGERS_COMPACT_HINTS"];
 
   if (fingers_compact_hints)
     fingers_hint_position = ENVIRON["FINGERS_HINT_POSITION"];
@@ -111,14 +111,14 @@ BEGIN {
     fingers_hint_position = ENVIRON["FINGERS_HINT_POSITION_NOCOMPACT"];
 
   if (fingers_compact_hints) {
-    hint_format = ENVIRON["FINGERS_HINT_FORMAT"]
-    hint_format_nocolor = ENVIRON["FINGERS_HINT_FORMAT_NOCOLOR"]
-    highlight_format = ENVIRON["FINGERS_HIGHLIGHT_FORMAT"]
+    hint_format              = ENVIRON["FINGERS_HINT_FORMAT"]
+    hint_format_nocolor      = ENVIRON["FINGERS_HINT_FORMAT_NOCOLOR"]
+    highlight_format         = ENVIRON["FINGERS_HIGHLIGHT_FORMAT"]
     highlight_format_nocolor = ENVIRON["FINGERS_HIGHLIGHT_FORMAT_NOCOLOR"]
   } else {
-    hint_format = ENVIRON["FINGERS_HINT_FORMAT_NOCOMPACT"]
-    highlight_format = ENVIRON["FINGERS_HIGHLIGHT_FORMAT_NOCOMPACT"]
-    hint_format_nocolor = ENVIRON["FINGERS_HINT_FORMAT_NOCOMPACT_NOCOLOR"]
+    hint_format              = ENVIRON["FINGERS_HINT_FORMAT_NOCOMPACT"]
+    highlight_format         = ENVIRON["FINGERS_HIGHLIGHT_FORMAT_NOCOMPACT"]
+    hint_format_nocolor      = ENVIRON["FINGERS_HINT_FORMAT_NOCOMPACT_NOCOLOR"]
     highlight_format_nocolor = ENVIRON["FINGERS_HIGHLIGHT_FORMAT_NOCOMPACT_NOCOLOR"]
   }
 
@@ -139,7 +139,7 @@ BEGIN {
   while (match(line, finger_patterns)) {
     pos += RSTART;
     col_pos = pos + col_pos_correction
-    pre_match = substr(output_line, 0, col_pos - 1);
+     pre_match = substr(output_line, 0, col_pos - 1);
     post_match = substr(output_line, col_pos + RLENGTH, length(line) - 1);
     line_match = substr(line, RSTART, RLENGTH);
 


### PR DESCRIPTION
### New functionality

* Adds single (but pretty big) regex to match all available kubernetes resources.
  - Assumes that resources aren't plural, which matches the output I get from `kubectl get all`. See https://github.com/ryankemper/tmux-fingers/commit/4761caf43581203531aa2781ea71cce83c421470

### Kubernetes Versioning Info

`kubectl version`: "v1.11.1" 
`kubectl client sha`: b1b29978270dc22fecc592ac55d903350454310a
`     as blob`: couldn't find specific blob for some reason, but found https://github.com/kubernetes/website/commit/75a0e41a99cd984b9deff17b7c589cfe65e277c4

which references it


`kubectl server version`: v1.9.7
`kubectl server sha`: dd5e1a2978fd0b97d9b78e1564398aeea7e7fe92
`     as blob`: https://github.com/NVIDIA/kubernetes/commit/dd5e1a2978fd0b97d9b78e1564398aeea7e7fe92

These might not technically be the most recent possible, but they're very recent so I believe the API should be the same.