### PR TITLE
Update health check tmux version parse regex

### DIFF
--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -111,7 +111,7 @@ function perform_health_check() {
   local healthy=1
 
   # BASH_VERSION is a global
-  local TMUX_VERSION=$(tmux -V | grep -Eio "[0-9]+(\.[0-9a-z])*$")
+  local TMUX_VERSION=$(tmux -V | grep -Eio "([0-9]+(\.[0-9]))(?:-rc)?$")
   local GAWK_VERSION=""
 
   if [[ $(program_exists "gawk") = "1" ]]; then


### PR DESCRIPTION
This updates the grep regex that parses the tmux version to allow for release candidate versions e.g. `tmux 2.7-rc`.