### PR TITLE
Really fix the tmux version parse for real this time

### DIFF
--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -111,7 +111,7 @@ function perform_health_check() {
   local healthy=1
 
   # BASH_VERSION is a global
-  local TMUX_VERSION=$(tmux -V | grep -Eio "([0-9]+(\.[0-9]))(?:-rc)?$")
+  local TMUX_VERSION=$(tmux -V | grep -Eio "([0-9]+(\.[0-9]))(?:-rc)?")
   local GAWK_VERSION=""
 
   if [[ $(program_exists "gawk") = "1" ]]; then


### PR DESCRIPTION
It turns out you need to remove the end of line check to really fix this. That's what I get for sending PR's with regex changes without actually checking my work... :man_facepalming: 