### PR TITLE
Remove redirection to /dev/null, fixing OSX open.

### DIFF
--- a/scripts/fingers.sh
+++ b/scripts/fingers.sh
@@ -125,13 +125,13 @@ function copy_result() {
   is_uppercase=$(echo "$input" | grep -E '^[a-z]+$' &> /dev/null; echo $?)
 
   if [[ $is_uppercase == "1" ]] && [ ! -z "$FINGERS_COPY_COMMAND_UPPERCASE" ]; then
-    tmux run-shell -b "printf \"$result\" | IS_UPPERCASE=$is_uppercase HINT=$hint $exec_prefix $FINGERS_COPY_COMMAND_UPPERCASE > /dev/null"
+    tmux run-shell -b "printf \"$result\" | IS_UPPERCASE=$is_uppercase HINT=$hint $exec_prefix $FINGERS_COPY_COMMAND_UPPERCASE"
   elif [ ! -z "$FINGERS_COPY_COMMAND" ]; then
-    tmux run-shell -b "printf \"$result\" | IS_UPPERCASE=$is_uppercase HINT=$hint $exec_prefix $FINGERS_COPY_COMMAND > /dev/null"
+    tmux run-shell -b "printf \"$result\" | IS_UPPERCASE=$is_uppercase HINT=$hint $exec_prefix $FINGERS_COPY_COMMAND"
   fi
 
   if [[ $HAS_TMUX_YANK = 1 ]]; then
-    tmux run-shell -b "printf \"$result\" | $exec_prefix $tmux_yank_copy_command > /dev/null"
+    tmux run-shell -b "printf \"$result\" | $exec_prefix $tmux_yank_copy_command"
   fi
 }
 


### PR DESCRIPTION
I tried to configure `tmux-fingers` as follows:

```
set -g @fingers-copy-command-uppercase 'xargs open'
```

To my surprise, nothing happened when I tried to use the `open` functionality. I did some investigation, and it looks like the redirection of output to `/dev/null` when running the command was somehow causing an issue on OSX. There shouldn't be any issue with removing the redirection since the command runs in the background with `-b`, so this pull request hopes to resolve the issue in that manner.