### PR TITLE
Pass current_pane_id as a parameter to copy command

### DIFF
--- a/scripts/fingers.sh
+++ b/scripts/fingers.sh
@@ -124,10 +124,18 @@ function copy_result() {
 
   is_uppercase=$(echo "$input" | grep -E '^[a-z]+$' &> /dev/null; echo $?)
 
+  copy_command_parameters=<<-EOS
+    printf \"$result\" |
+      IS_UPPERCASE=$is_uppercase
+      HINT=$hint
+      CURRENT_PANE_ID=$current_pane_id
+      $exec_prefix
+  EOS
+
   if [[ $is_uppercase == "1" ]] && [ ! -z "$FINGERS_COPY_COMMAND_UPPERCASE" ]; then
-    tmux run-shell -b "printf \"$result\" | IS_UPPERCASE=$is_uppercase HINT=$hint $exec_prefix $FINGERS_COPY_COMMAND_UPPERCASE"
+    tmux run-shell -b "$copy_command_parameters $FINGERS_COPY_COMMAND_UPPERCASE"
   elif [ ! -z "$FINGERS_COPY_COMMAND" ]; then
-    tmux run-shell -b "printf \"$result\" | IS_UPPERCASE=$is_uppercase HINT=$hint $exec_prefix $FINGERS_COPY_COMMAND"
+    tmux run-shell -b "$copy_command_parameters $FINGERS_COPY_COMMAND"
   fi
 
   if [[ $HAS_TMUX_YANK = 1 ]]; then


### PR DESCRIPTION
Passing this variable allows the copy command to interact with the
current pane (tmux send-keys, for example).

A useful example of this is:
`set -g @fingers-copy-command-uppercase 'xargs tmux send-keys -t "$current_pane_id"'` to do an automatic copy&paste with one shortcut.

Btw, kudos for this great plugin. It's what made me switch from screen :)