### PR TITLE
Fix: Patterns matching the empty string rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0 - 06 Mar 2020
+
+* Extended default SHA pattern to match up to 128 digits ( fixes #73 )
+
 ## 1.0.1 - 05 Jan 2020
 
 * Fix default open command discovery ( fixes #70 )

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ set -g @fingers-pattern-1 'yolo'
 set -g @fingers-pattern-50 'whatever'
 ```
 
-Patterns are case insensitive, and grep's extended syntax ( ERE ) should be used.
+Patterns are case insensitive, and grep's extended syntax ( ERE ) should be used. Patterns
+matching the empty string are disallowed.
 `man grep` for more info.
 
 If the introduced regexp contains an error, an error will be shown when

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -7,11 +7,18 @@ TMUX_PRINTER="$CONF_CURRENT_DIR/../vendor/tmux-printer/tmux-printer"
 
 declare -A fingers_defaults
 
-# TODO empty patterns are invalid
 function check_pattern() {
   echo "beep beep" | grep -e "$1" 2> /dev/null
 
   if [[ $? == "2" ]]; then
+    echo 0
+  else
+    echo 1
+  fi
+}
+
+function check_matches_empty_string() {
+  if ! grep -e "$1" <<< "" >/dev/null; then
     echo 0
   else
     echo 1
@@ -108,6 +115,14 @@ for pattern in "${PATTERNS_LIST[@]}" ; do
     display_message "fingers-error: bad user defined pattern $pattern" 5000
     PATTERNS_LIST[$i]="nope{4000}"
   fi
+
+  pattern_matches_empty=$(check_matches_empty_string "$pattern")
+
+  if [[ $pattern_matches_empty == 0 ]]; then
+    display_message "fingers-error: user defined pattern $pattern matched the empty string" 5000
+    PATTERNS_LIST[$i]="nope{4000}"
+  fi
+
 
   i=$((i + 1))
 done

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -8,7 +8,7 @@ TMUX_PRINTER="$CONF_CURRENT_DIR/../vendor/tmux-printer/tmux-printer"
 declare -A fingers_defaults
 
 function check_pattern() {
-  echo "beep beep" | grep -e "$1" 2> /dev/null
+  echo "beep beep" | grep -E -e "$1" 2> /dev/null
 
   if [[ $? == "2" ]]; then
     echo 0
@@ -18,7 +18,7 @@ function check_pattern() {
 }
 
 function check_matches_empty_string() {
-  if ! grep -e "$1" <<< "" >/dev/null; then
+  if grep -E -e "$1" <<< "" >/dev/null; then
     echo 0
   else
     echo 1
@@ -122,7 +122,6 @@ for pattern in "${PATTERNS_LIST[@]}" ; do
     display_message "fingers-error: user defined pattern $pattern matched the empty string" 5000
     PATTERNS_LIST[$i]="nope{4000}"
   fi
-
 
   i=$((i + 1))
 done


### PR DESCRIPTION
As observed in #86, fingers accepts a pattern accepting an empty string, such as `(token)?`, and this leads the `gawk` subprocess to loop indefinitely, allocated memory until it's eventually killed by the kernel.
This pr rejects such patterns, printing an error message.
