### PR TITLE
expand_path only if the match starts with ~

### DIFF
--- a/src/fingers/action_runner.cr
+++ b/src/fingers/action_runner.cr
@@ -124,9 +124,14 @@ module Fingers
 
     # This takes care of some path expansion weirdness when opening paths that start with ~ in MacOS
     def expanded_match
-      return match unless action == ":open:" && match.starts_with?("~")
+      return match unless should_expand_match?
 
       Path[match].expand(base: original_pane.pane_current_path, home: Path.home)
     end
+
+    private def should_expand_match?
+      action == ":open:" && match.starts_with?("~")
+    end
+
   end
 end

--- a/src/fingers/action_runner.cr
+++ b/src/fingers/action_runner.cr
@@ -124,7 +124,7 @@ module Fingers
 
     # This takes care of some path expansion weirdness when opening paths that start with ~ in MacOS
     def expanded_match
-      return match unless action == ":open:"
+      return match unless action == ":open:" && match.starts_with?("~")
 
       Path[match].expand(base: original_pane.pane_current_path, home: Path.home)
     end


### PR DESCRIPTION
expand_path mangles URL matches like

`https://github.com/Morantron/tmux-fingers`

when performing the `:open:` action, because it's doing `Path.expand` on a URL, not a path.

Without this PR, ctrl-n with the above match outputs to `/tmp/action-stderr`

```
The file /Users/brttbndr/https:/github.com/Morantron/tmux-fingers does not exist.
```

and the URL is not opened in my browser.

With this PR, we get no output to stderr and the URL is opened in the browser.
