### PR TITLE
Add methods to track and restore key-table

### DIFF
--- a/src/fingers/commands/start.cr
+++ b/src/fingers/commands/start.cr
@@ -27,8 +27,8 @@ module Fingers::Commands
 
   class Start < Cling::Command
     @original_options : Hash(String, String) = {} of String => String
-    @last_key_table : String | Nil
-    @last_pane_id : String = "root"
+    @last_key_table : String = "root"
+    @last_pane_id : String | Nil
     @mode : String = "default"
     @pane_id : String = ""
     @patterns : Array(String) = [] of String


### PR DESCRIPTION
On teardown, set key-table to the tracked value, or "root" if empty for some reason.

Allows the user to call tmux-fingers from any key-table, perform an action, and revert.