### PR TITLE
implement shell-command option for cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,15 @@ set -g @fingers-pattern-yolo "yolo.*"
 bind y run -b "#{@fingers-cli} start #{pane_id} --patterns yolo"
 ```
 
+## Using arbitrary commands
+
+You can use tmux-fingers with any arbitrary command.
+
+```
+# edit file using nvim in a new tmux window with prefix + e
+bind e run -b "#{@fingers-cli} start #{pane_id} --patterns path --shell-command 'xargs tmux new-window nvim'"
+```
+
 # Acknowledgements and inspiration
 
 This plugin is heavily inspired by

--- a/README.md
+++ b/README.md
@@ -300,17 +300,17 @@ You can start tmux-fingers with an specific set of built-in or custom patterns.
 
 ```
 # match urls with prefix + u
-bind -n u run -b "#{@fingers-cli} start #{pane_id} --patterns url"
+bind u run -b "#{@fingers-cli} start #{pane_id} --patterns url"
 
 # match hashes with prefix + h
-bind -n h run -b "#{@fingers-cli} start #{pane_id} --patterns sha"
+bind h run -b "#{@fingers-cli} start #{pane_id} --patterns sha"
 
 # match git stuff with prefix + g
-bind -n g run -b "#{@fingers-cli} start #{pane_id} --patterns git-status,git-status-branch"
+bind g run -b "#{@fingers-cli} start #{pane_id} --patterns git-status,git-status-branch"
 
 # match custom pattern with prefix + y
 set -g @fingers-pattern-yolo "yolo.*"
-bind -n y run -b "#{@fingers-cli} start #{pane_id} --patterns yolo"
+bind y run -b "#{@fingers-cli} start #{pane_id} --patterns yolo"
 ```
 
 # Acknowledgements and inspiration

--- a/src/fingers/action_runner.cr
+++ b/src/fingers/action_runner.cr
@@ -4,7 +4,8 @@ module Fingers
   class ActionRunner
     @final_shell_command : String | Nil
 
-    def initialize(@modifier : String, @match : String, @hint : String, @original_pane : Tmux::Pane, @offset : Tuple(Int32, Int32) | Nil, @mode : String)
+    def initialize(@modifier : String, @match : String, @hint : String, @original_pane : Tmux::Pane,
+      @offset : Tuple(Int32, Int32) | Nil, @mode : String, @shell_command : String | Nil)
     end
 
     def run
@@ -28,24 +29,28 @@ module Fingers
       cmd.input.flush
     end
 
-    private getter :match, :modifier, :hint, :original_pane, :offset, :mode
+    private getter :match, :modifier, :hint, :original_pane, :offset, :mode, :shell_command
 
     def final_shell_command
       return jump if mode == "jump"
       return @final_shell_command if @final_shell_command
 
-      @final_shell_command = case action
-                             when ":copy:"
-                               copy
-                             when ":open:"
-                               open
-                             when ":paste:"
-                               paste
-                             when nil
-                               # do nothing
-                             else
-                               shell_action
-                             end
+      @final_shell_command = shell_command || action_command
+    end
+
+    private def action_command
+      case action
+      when ":copy:"
+        copy
+      when ":open:"
+        open
+      when ":paste:"
+        paste
+      when nil
+        # do nothing
+      else
+        shell_action
+      end
     end
 
     def copy

--- a/src/fingers/commands/start.cr
+++ b/src/fingers/commands/start.cr
@@ -31,6 +31,7 @@ module Fingers::Commands
     @mode : String = "default"
     @pane_id : String = ""
     @patterns : Array(String) = [] of String
+    @shell_command : String | Nil
 
     def setup : Nil
       @name = "start"
@@ -43,6 +44,10 @@ module Fingers::Commands
       add_option "patterns",
                  description: "comma separated list of pattern names",
                  type: :single
+
+      add_option "shell-command",
+                 description: "command to which the output will be piped",
+                 type: :single
     end
 
     def run(arguments, options) : Nil
@@ -53,6 +58,10 @@ module Fingers::Commands
         @patterns = patterns_from_options(options.get("patterns").as_s)
       else
         @patterns = Fingers.config.patterns.values
+      end
+
+      if options.has?("shell-command")
+        @shell_command = shell_command_from_options(options.get("shell-command").as_s)
       end
 
       track_options_to_restore
@@ -84,6 +93,15 @@ module Fingers::Commands
       end
 
       result
+    end
+
+    private def shell_command_from_options(shell_command_option : String)
+      if shell_command_option.blank?
+        tmux.display_message("[tmux-fingers] error: shell-command can not be blank", 5000)
+        exit 0
+      end
+
+      shell_command_option
     end
 
     private def track_options_to_restore
@@ -202,7 +220,8 @@ module Fingers::Commands
         output: pane_printer,
         original_pane: target_pane,
         tmux: tmux,
-        mode: mode
+        mode: mode,
+        shell_command: @shell_command
       )
     end
 

--- a/src/fingers/view.cr
+++ b/src/fingers/view.cr
@@ -14,6 +14,7 @@ module Fingers
     @original_pane : Tmux::Pane
     @tmux : Tmux
     @mode : String
+    @shell_command : String | Nil
 
     def initialize(
       @hinter,
@@ -21,7 +22,8 @@ module Fingers
       @original_pane,
       @state,
       @tmux,
-      @mode
+      @mode,
+      @shell_command
     )
     end
 
@@ -63,7 +65,8 @@ module Fingers
         match: state.result,
         original_pane: original_pane,
         offset: match ? match.not_nil!.offset : nil,
-        mode: mode
+        mode: mode,
+        shell_command: shell_command
       ).run
 
       tmux.display_message("Copied: #{state.result}", 1000) if should_notify?
@@ -103,7 +106,7 @@ module Fingers
       end
     end
 
-    private getter :output, :hinter, :original_pane, :state, :tmux, :mode
+    private getter :output, :hinter, :original_pane, :state, :tmux, :mode, :shell_command
 
     private def handle_match(match)
       if state.multi_mode


### PR DESCRIPTION
This PR add the cli option `--shell-command` allowing execute arbitrary commands besides that defined in `@fingers-*-action`.

### Motivation

I have some specific workflows I would like to use the power of tmux-fingers, but I want keep the standard `@fingers-key` and its modifier for general purpose stuffs.