### PR TITLE
add config to allow preventing :paste: from affecting system clipboard

### DIFF
--- a/src/fingers/action_runner.cr
+++ b/src/fingers/action_runner.cr
@@ -19,7 +19,7 @@ module Fingers
     end
 
     def run
-      tmux.set_buffer(match)
+      tmux.set_buffer(match, Fingers.config.copy_on_paste)
 
       return if final_shell_command.nil? || final_shell_command.not_nil!.empty?
 

--- a/src/fingers/commands/load_config.cr
+++ b/src/fingers/commands/load_config.cr
@@ -56,6 +56,8 @@ class Fingers::Commands::LoadConfig < Cling::Command
         config.alt_action = value
       when "shift_action"
         config.shift_action = value
+      when "copy_on_paste"
+        config.copy_on_paste = to_bool(value)
       when "benchmark_mode"
         config.benchmark_mode = value
       when "hint_position"

--- a/src/fingers/commands/start.cr
+++ b/src/fingers/commands/start.cr
@@ -37,6 +37,7 @@ module Fingers::Commands
     @ctrl_action : String | Nil
     @shift_action : String | Nil
     @alt_action : String | Nil
+    @copy_on_paste : Bool = true
 
     def setup : Nil
       @name = "start"
@@ -68,6 +69,11 @@ module Fingers::Commands
                  description: "command to which the output will be pipedwhen holding SHIFT key",
                  type: :single
 
+      add_option "copy-on-paste",
+                 description: "whether the :paste: command should copy to the system clipboard",
+                 default: true,
+                 type: :single
+
       add_option 'h', "help", description: "prints help"
     end
 
@@ -94,6 +100,7 @@ module Fingers::Commands
       @ctrl_action = options.get?("ctrl-action").try(&.as_s)
       @alt_action = options.get?("alt-action").try(&.as_s)
       @shift_action = options.get?("shift-action").try(&.as_s)
+      @copy_on_paste = options.get("copy-on-paste").try(&.as_bool)
 
       track_tmux_state
 
@@ -213,6 +220,7 @@ module Fingers::Commands
         ctrl_action: @ctrl_action,
         alt_action: @alt_action,
         shift_action: @shift_action,
+        copy_on_paste: @copy_on_paste,
       ).run
 
       tmux.display_message("Copied: #{state.result}", 1000) if should_notify?

--- a/src/fingers/config.cr
+++ b/src/fingers/config.cr
@@ -14,6 +14,7 @@ module Fingers
     property ctrl_action : String
     property alt_action : String
     property shift_action : String
+    property copy_on_paste : Bool
     property hint_position : String
     property hint_style : String
     property selected_hint_style : String
@@ -73,6 +74,7 @@ module Fingers
       @ctrl_action = ":open:",
       @alt_action = "",
       @shift_action = ":paste:",
+      @copy_on_paste = true,
       @hint_position = "left",
       @hint_style = FORMAT_PRINTER.print("fg=green,bold"),
       @highlight_style = FORMAT_PRINTER.print("fg=yellow"),

--- a/src/tmux.cr
+++ b/src/tmux.cr
@@ -228,10 +228,10 @@ class Tmux
     exec(["show", "-gqv", name].join(' ')).chomp
   end
 
-  def set_buffer(value)
+  def set_buffer(value, copy_on_paste)
     return unless value
 
-    if @version >= Tmux.tmux_version_to_semver("3.2")
+    if @version >= Tmux.tmux_version_to_semver("3.2") && copy_on_paste
       args = ["load-buffer", "-w", "-"]
     else
       args = ["load-buffer", "-"]


### PR DESCRIPTION
Currently `:paste:` impacts your system clipboard; however, a pretty huge use-case (for me, 
and potentially many) is to simply paste it into the buffer without changing your clipboard.
I do this so often for so many things, since I use it as a way to continue in my terminal without
my mouse, but don't actually need any of this lingering in my clipboard since I have no other
use for it.

This adds an option to do that.

Now, with `set -g @fingers-copy-on-paste 0`, users can achieve this behavior, while the default
is preserved. Since the basic command is `load-buffer -w`, there is no way to achieve this with
the current configuration options.

(For context, I moved to this from https://github.com/fcsonline/tmux-thumbs, where I would set 
`set -g @thumbs-command 'tmux set-buffer -- {} && tmux paste-buffer'` to achieve the same)