### PR TITLE
Handle empty pane_current_path when changing directory

### DIFF
--- a/src/fingers/action_runner.cr
+++ b/src/fingers/action_runner.cr
@@ -31,7 +31,7 @@ module Fingers
         input: :pipe,
         output: :pipe,
         error: File.open(::Fingers::Dirs::ROOT / "action-stderr", "a"),
-        chdir: original_pane.pane_current_path,
+        chdir: original_pane.pane_current_path.presence,
         env: action_env
       )
 


### PR DESCRIPTION
Hi, thank you for the nice plugin.

I encountered an issue where the tmux session crashes when copying a file path to the clipboard with tmux-fingers.

(Sorry, this only occurs in my closed production code, so I cannot share the steps to reproduce it)

<details>
<summary>The issue produces the following log:</summary>


```
Unhandled exception: Error executing process: 'pbcopy': Error while changing directory: '': No such file or directory (File::NotFoundError)
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/crystal/system/unix/dir.cr:80:7 in 'current='
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/dir.cr:191:5 in 'cd'
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/crystal/system/unix/process.cr:330:5 in 'try_replace'
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/crystal/system/unix/process.cr:250:9 in 'spawn'
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/process.cr:280:5 in 'initialize:input:output:error:chdir:env'
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/process.cr:272:3 in 'new:input:output:error:chdir:env'
  from src/fingers/action_runner.cr:28:7 in 'run'
  from src/fingers/commands/start.cr:205:7 in 'process_result'
  from src/fingers/commands/start.cr:107:7 in 'run'
  from lib/cling/src/cling/executor.cr:59:7 in 'handle'
  from lib/cling/src/cling/command.cr:182:7 in 'execute'
  from src/fingers/cli.cr:25:7 in 'run'
  from src/fingers.cr:8:3 in '__crystal_main'
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/crystal/main.cr:129:5 in 'main_user_code'
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/crystal/main.cr:115:7 in 'main'
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/crystal/system/unix/main.cr:9:3 in 'main'
 (RuntimeError)
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/crystal/system/unix/process.cr:276:9 in 'spawn'
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/process.cr:280:5 in 'initialize:input:output:error:chdir:env'
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/process.cr:272:3 in 'new:input:output:error:chdir:env'
  from src/fingers/action_runner.cr:28:7 in 'run'
  from src/fingers/commands/start.cr:205:7 in 'process_result'
  from src/fingers/commands/start.cr:107:7 in 'run'
  from lib/cling/src/cling/executor.cr:59:7 in 'handle'
  from lib/cling/src/cling/command.cr:182:7 in 'execute'
  from src/fingers/cli.cr:25:7 in 'run'
  from src/fingers.cr:8:3 in '__crystal_main'
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/crystal/main.cr:129:5 in 'main_user_code'
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/crystal/main.cr:115:7 in 'main'
  from /opt/homebrew/Cellar/crystal/1.17.1/share/crystal/src/crystal/system/unix/main.cr:9:3 in 'main'
```
</details>

Specifically, it seems that the issue occurs when attempting to change directory with an empty string:

> Unhandled exception: Error executing process: 'pbcopy': Error while changing directory: '': No such file or directory (File::NotFoundError)

The empty string passed to the change directory command appears to come from tmux's `pane_current_path`.
I couldn't determine why this value becomes empty, but I found that [the tmux(1) manual describes pane_current_path as "Current path if available"](https://github.com/tmux/tmux/blob/6f9bcb7fee5f5aace29f5c3e474aaa61e8c34bfd/tmux.1#L6107).

In fact, tmux has had several issues where `pane_current_path` becomes empty:

- https://github.com/tmux/tmux/issues/1532
- https://github.com/tmux/tmux/issues/3176

If `pane_current_path` is an empty string, chdir will crash. So I've used [String#presence](https://crystal-lang.org/api/1.17.1/String.html#presence%3Aself%7CNil-instance-method) to handle this case.

To be honest, I feel this fix is somewhat ad-hoc, so I don't mind if you close this PR and implement a different solution.

Thanks.


