### PR TITLE
Fix: close stdin before waiting for load-buffer command

### DIFF
--- a/src/tmux.cr
+++ b/src/tmux.cr
@@ -244,7 +244,7 @@ class Tmux
     )
 
     cmd.input.print(value)
-    cmd.input.flush
+    cmd.input.close
 
     cmd.wait
 


### PR DESCRIPTION
The set_buffer method writes to tmux load-buffer via stdin pipe but only flushes without closing. Since load-buffer reads until EOF, the command may not complete properly, especially when using the -w flag for OSC52 clipboard integration through nested tmux/SSH.

Replacing flush with close signals EOF and allows the command to complete, ensuring the OSC52 escape sequence is properly sent.

Tested this within nested and non-nested tmux sessions, and it fixes the copy problem for me.