### PR TITLE
remove tput calls

### DIFF
--- a/spec/lib/tmux_style_printer_spec.cr
+++ b/spec/lib/tmux_style_printer_spec.cr
@@ -1,25 +1,11 @@
 require "spec"
 require "../../src/tmux_style_printer"
 
-class FakeShell < TmuxStylePrinter::Shell
-  def exec(cmd)
-    "$(#{cmd})"
-  end
-end
-
 describe TmuxStylePrinter do
   it "transforms tmux status line format into escape sequences" do
-    printer = TmuxStylePrinter.new(shell = FakeShell.new)
+    printer = TmuxStylePrinter.new
     result = printer.print("bg=red,fg=yellow,bold", reset_styles_after: true)
-    expected = "$(tput setab 1)$(tput setaf 3)$(tput bold)$(tput sgr0)"
-
-    result.should eq expected
-  end
-
-  it "transforms tmux status line format into escape sequences" do
-    printer = TmuxStylePrinter.new(shell = FakeShell.new)
-    result = printer.print("bg=red,fg=yellow,bold", reset_styles_after: true)
-    expected = "$(tput setab 1)$(tput setaf 3)$(tput bold)$(tput sgr0)"
+    expected = "\e[48;5;1m\e[38;5;3m\e[1m\e[0m"
 
     result.should eq expected
   end

--- a/src/tmux_style_printer.cr
+++ b/src/tmux_style_printer.cr
@@ -3,10 +3,6 @@ class TmuxStylePrinter
   class InvalidFormat < Exception
   end
 
-  abstract class Shell
-    abstract def exec(cmd)
-  end
-
   STYLE_SEPARATOR = /[ ,]+/
 
   COLOR_MAP = {
@@ -20,32 +16,25 @@ class TmuxStylePrinter
     white:   7,
   }
 
-  LAYER_MAP = {
-    bg: "setab",
-    fg: "setaf",
+  LAYER_CODE = {
+    "bg" => 48,
+    "fg" => 38,
   }
 
   STYLE_MAP = {
-    bright:     "bold",
-    bold:       "bold",
-    dim:        "dim",
-    underscore: "smul",
-    reverse:    "rev",
-    italics:    "sitm",
+    "bright"     => "\e[1m",
+    "bold"       => "\e[1m",
+    "dim"        => "\e[2m",
+    "underscore" => "\e[4m",
+    "reverse"    => "\e[7m",
+    "italics"    => "\e[3m",
   }
 
-  class ShellExec < Shell
-    def exec(cmd)
-      `#{cmd}`.chomp
-    end
-  end
+  RESET = "\e[0m"
 
-  @shell : Shell
   @applied_styles : Hash(String, String)
-  @reset_sequence : String | Nil
 
-  def initialize(shell = ShellExec.new)
-    @shell = shell
+  def initialize
     @applied_styles = {} of String => String
   end
 
@@ -58,7 +47,7 @@ class TmuxStylePrinter
       output += parse_style_definition(style)
     end
 
-    output += reset_sequence if reset_styles_after && !@applied_styles.empty?
+    output += RESET if reset_styles_after && !@applied_styles.empty?
 
     output
   end
@@ -89,7 +78,7 @@ class TmuxStylePrinter
 
     raise InvalidFormat.new("Invalid color definition: #{style}") if color_to_apply.nil?
 
-    result = shell.exec("tput #{LAYER_MAP[layer]} #{color_to_apply}")
+    result = "\e[#{LAYER_CODE[layer]};5;#{color_to_apply}m"
 
     @applied_styles[layer] = result
 
@@ -108,7 +97,7 @@ class TmuxStylePrinter
 
     raise InvalidFormat.new("Invalid style definition: #{style}") if style_to_apply.nil?
 
-    result = style == "dim" ? "\033[2m" : shell.exec("tput #{STYLE_MAP[style]}")
+    result = style_to_apply
 
     if should_remove_style
       @applied_styles.delete(style)
@@ -121,14 +110,6 @@ class TmuxStylePrinter
   end
 
   private def reset_to_applied_styles!
-    [reset_sequence, @applied_styles.values].join
-  end
-
-  private def reset_sequence
-    @reset_sequence ||= shell.exec("tput sgr0").chomp
-  end
-
-  private def shell
-    @shell
+    [RESET, @applied_styles.values].join
   end
 end


### PR DESCRIPTION
I've noticed `tmux-fingers` shells out to compute the default styles on _every_ call.

```crystal
      @hint_style = FORMAT_PRINTER.print("fg=green,bold"),
      @highlight_style = FORMAT_PRINTER.print("fg=yellow"),
      @selected_hint_style = FORMAT_PRINTER.print("fg=blue,bold"),
      @selected_highlight_style = FORMAT_PRINTER.print("fg=blue"),
```

The performance improvement is huge 🫠 

```
+------------------------------------------+----------------+----------------+----------------+----------------+
| Version                                  | Mean           | Std Dev        | Min            | Max            |
+------------------------------------------+----------------+----------------+----------------+----------------+
| 036654d9fe9ec17d3f957f70da0e6428ef84f5bd | 0.017351s      | 0.000333s      | 0.016795s      | 0.019934s      |
| develop                                  | 0.037160s      | 0.000793s      | 0.036055s      | 0.041379s      |
+------------------------------------------+----------------+----------------+----------------+----------------+
```

I'm removing `tput` dependency altogether: even if default styles are computed on every call, this is very cheap.