### PR TITLE
Add kubernetes-pod builtin pattern for pod names

### DIFF
--- a/src/fingers/config.cr
+++ b/src/fingers/config.cr
@@ -37,6 +37,11 @@ module Fingers
       "path": "(([.\\w\\-~\\$@]+)?(/[.\\w\\-@]+)+/?)",
       "hex": "(0x[0-9a-fA-F]+)",
       "kubernetes": "(deployment.app|binding|componentstatuse|configmap|endpoint|event|limitrange|namespace|node|persistentvolumeclaim|persistentvolume|pod|podtemplate|replicationcontroller|resourcequota|secret|serviceaccount|service|mutatingwebhookconfiguration.admissionregistration.k8s.io|validatingwebhookconfiguration.admissionregistration.k8s.io|customresourcedefinition.apiextension.k8s.io|apiservice.apiregistration.k8s.io|controllerrevision.apps|daemonset.apps|deployment.apps|replicaset.apps|statefulset.apps|tokenreview.authentication.k8s.io|localsubjectaccessreview.authorization.k8s.io|selfsubjectaccessreviews.authorization.k8s.io|selfsubjectrulesreview.authorization.k8s.io|subjectaccessreview.authorization.k8s.io|horizontalpodautoscaler.autoscaling|cronjob.batch|job.batch|certificatesigningrequest.certificates.k8s.io|events.events.k8s.io|daemonset.extensions|deployment.extensions|ingress.extensions|networkpolicies.extensions|podsecuritypolicies.extensions|replicaset.extensions|networkpolicie.networking.k8s.io|poddisruptionbudget.policy|clusterrolebinding.rbac.authorization.k8s.io|clusterrole.rbac.authorization.k8s.io|rolebinding.rbac.authorization.k8s.io|role.rbac.authorization.k8s.io|storageclasse.storage.k8s.io)[[:alnum:]_#$%&+=/@-]+",
+      # Matches deployment-managed pod names like "nginx-deployment-66b6c48dd5-7xb2r".
+      # K8s generates hashes using a restricted alphabet (no vowels, no 0/1/3)
+      # to avoid accidental profanity: "bcdfghjklmnpqrstvwxz2456789"
+      # See: https://github.com/kubernetes/apimachinery/blob/master/pkg/util/rand/rand.go
+      "kubernetes-pod": "[a-z][a-z0-9-]*[a-z0-9]-[bcdfghjklmnpqrstvwxz2456789]{5,10}-[bcdfghjklmnpqrstvwxz2456789]{5}",
       "git-status": "(modified|deleted|deleted by us|new file): +(?<match>.+)",
       "git-status-branch": "Your branch is up to date with '(?<match>.*)'.",
       "diff": "(---|\\+\\+\\+) [ab]/(?<match>.*)",


### PR DESCRIPTION
First of all, thanks for such an awesome tool!

The existing "kubernetes" pattern matches resource type paths (e.g. deployment.apps/my-app) but not pod names, which are the most commonly copied k8s identifiers for kubectl logs, describe, exec, etc.

Pod names like "nginx-deployment-66b6c48dd5-7xb2r" have a distinctive structure: `<name>-<replicaset-hash>-<pod-hash>`.  The regex uses the actual k8s hash alphabet (consonants + digits 2,4-9, no vowels) from apimachinery/pkg/util/rand, which avoids false positives on normal terminal text.