### PR TITLE
update install-wizard and readme to show that shards is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.7.0 - 31 May 2026
+
+* improved performance: ~30% faster
+* added macOS arm64 binary to the release/download pipeline
+* added kubernetes-pod builtin pattern for pod names
+* fixed clipboard integration in WSL
+* fixed various styling rendering issues related to submatches and backdrop
+* removed tput dependency
+* improved error handling
+* refactored option parsing, now with stricter validation
+* updated to crystal 1.19
+
 ## 2.6.2 - 15 Feb 2026
 
 * Fix line jumping and backdrop-style rendering issues related with tabs,

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ set -g @plugin 'Morantron/tmux-fingers'
 
 Hit <kbd>prefix</kbd> + <kbd>I</kbd> to fetch and source the plugin. The first time you run it you'll be presented with a wizard to complete the installation. Depending on the platform, the wizard will offer the following installation methods:
 
-- Building from source (requires [crystal](https://crystal-lang.org/install/)). _Available in all platforms_
+- Building from source (requires [crystal](https://crystal-lang.org/install/) and its package manager [shards](https://crystal-lang.org/reference/latest/man/shards/index.html)). _Available in all platforms_
 - Install through [brew](https://brew.sh). _Mac OS only_.
 - Download standalone binary. _Linux x86 only_.
 

--- a/install-wizard.sh
+++ b/install-wizard.sh
@@ -31,11 +31,20 @@ trap finish EXIT
 function install_from_source() {
   echo "Installing from source..."
 
-  # check if shards is installed
-  if ! command -v shards >/dev/null 2>&1; then
+  # check if crystal is installed
+  if ! command -v crystal >/dev/null 2>&1; then
     echo "crystal is not installed. Please install it first."
     echo ""
     echo "  https://crystal-lang.org/install/"
+    echo ""
+    exit 1
+  fi
+
+  # check if shards is installed
+  if ! command -v shards >/dev/null 2>&1; then
+    echo "shards is not installed. Please install it first."
+    echo ""
+    echo "  https://crystal-lang.org/reference/latest/man/shards/index.html"
     echo ""
     exit 1
   fi


### PR DESCRIPTION
This PR fixes #165.
- Updates the README to mention that crystal's package manager shards is required to build from source
- Adds a separate check for the `shards` command in the install-wizard that links to the shards reference page