### PR TITLE
Add macOS arm64 binary to the release/download pipeline

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -27,6 +27,36 @@ jobs:
         asset_path: ./bin/tmux-fingers
         asset_name: tmux-fingers-${{ github.event.release.tag_name }}-linux-x86_64
         asset_content_type: binary/octet-stream
+  dist_macos_arm64:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Crystal
+      uses: crystal-lang/install-crystal@v1
+      with:
+        crystal: "1.14"
+    - name: Install static lib dependencies
+      run: brew install bdw-gc pcre2
+    - name: Prepare static libs
+      run: |
+        mkdir -p bin
+        ln -sf $(brew --prefix bdw-gc)/lib/libgc.a bin/libgc.a
+        ln -sf $(brew --prefix pcre2)/lib/libpcre2-8.a bin/libpcre2-8.a
+    - name: Build
+      run: |
+        shards build --production --release --no-debug \
+          --link-flags="-L $(pwd)/bin $(pwd)/bin/libgc.a $(pwd)/bin/libpcre2-8.a"
+      env:
+        WIZARD_INSTALLATION_METHOD: download-binary
+    - name: Upload
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./bin/tmux-fingers
+        asset_name: tmux-fingers-${{ github.event.release.tag_name }}-macos-arm64
+        asset_content_type: binary/octet-stream
   dist_homebrew:
     name: Bump Homebrew formula
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ set -g @plugin 'Morantron/tmux-fingers'
 Hit <kbd>prefix</kbd> + <kbd>I</kbd> to fetch and source the plugin. The first time you run it you'll be presented with a wizard to complete the installation. Depending on the platform, the wizard will offer the following installation methods:
 
 - Building from source (requires [crystal](https://crystal-lang.org/install/)). _Available in all platforms_
-- Install through [brew](https://brew.sh). _Mac OS only_.
-- Download standalone binary. _Linux x86 only_.
+- Install through [brew](https://brew.sh). _macOS only_.
+- Download standalone binary. _Linux x86_64 and macOS arm64 only_.
 
 ## Manual
 

--- a/install-wizard.sh
+++ b/install-wizard.sh
@@ -58,27 +58,37 @@ function install_with_brew() {
 }
 
 
-function download_binary() {
-  mkdir -p $CURRENT_DIR/bin
+function asset_suffix() {
+  local arch=$(uname -m)
 
-  if [[ ! "$(uname -m)" == "x86_64" ]]; then
-    echo "tmux-fingers binaries are only provided for x86_64 architecture."
+  if [[ "$PLATFORM" == "Linux" && "$arch" == "x86_64" ]]; then
+    echo "linux-x86_64"
+  elif [[ "$PLATFORM" == "Darwin" && "$arch" == "arm64" ]]; then
+    echo "macos-arm64"
+  fi
+}
+
+function download_binary() {
+  local suffix=$(asset_suffix)
+
+  if [[ -z "$suffix" ]]; then
+    echo "No pre-built binary available for your platform ($(uname -s) $(uname -m))."
     exit 1
   fi
 
+  mkdir -p $CURRENT_DIR/bin
+
   echo "Getting latest release..."
 
-  # TODO use "latest" tag
-  url=$(curl -s "https://api.github.com/repos/morantron/tmux-fingers/releases" | grep browser_download_url | head -1 | grep -o https://.*x86_64)
-
-  echo "Downloading binary from $url"
+  url=$(curl -s "https://api.github.com/repos/Morantron/tmux-fingers/releases" | grep -o "https://.*${suffix}" | head -1)
 
   if [[ -z "$url" ]]; then
     echo "Could not find a release for tmux-fingers. Please try again later."
     exit 1
   fi
 
-  # download binary to bin/tmux-fingers
+  echo "Downloading binary from $url"
+
   curl -L $url -o $CURRENT_DIR/bin/tmux-fingers
   chmod a+x $CURRENT_DIR/bin/tmux-fingers
 
@@ -100,40 +110,37 @@ if [[ "$1" == "install-from-source" ]]; then
   install_from_source
 fi
 
-function binary_or_brew_label() {
-  if [[ "$PLATFORM" == "Darwin" ]]; then
-    echo "Install with brew"
-  else
-    echo "Download binary"
-  fi
-}
-
-function binary_or_brew_action() {
-  if [[ "$PLATFORM" == "Darwin" ]]; then
-    echo "install-with-brew"
-  else
-    echo "download-binary"
-  fi
-}
-
 function get_message() {
   if [[ "$FINGERS_UPDATE" == "1" ]]; then
     echo "It looks like tmux-fingers has been updated. We need to rebuild the binary."
   else
    echo "It looks like it is the first time you are running the plugin. We first need to get tmux-fingers binary for things to work."
   fi
-
 }
 
-tmux display-menu -T "tmux-fingers" \
-  "" \
-  "- " "" ""\
-  "-  #[nodim,bold]Welcome to tmux-fingers! ✌️ " "" ""\
-  "- " "" ""\
-  "-  $(get_message) " "" "" \
-  "- " "" ""\
-  "" \
-  "$(binary_or_brew_label)" b "new-window \"$CURRENT_DIR/install-wizard.sh $(binary_or_brew_action)\"" \
-  "Build from source (crystal required)" s "new-window \"$CURRENT_DIR/install-wizard.sh install-from-source\"" \
-  "" \
+menu_args=(
+  -T "tmux-fingers"
+  ""
+  "- " "" ""
+  "-  #[nodim,bold]Welcome to tmux-fingers! ✌️ " "" ""
+  "- " "" ""
+  "-  $(get_message) " "" ""
+  "- " "" ""
+  ""
+)
+
+if [[ -n "$(asset_suffix)" ]]; then
+  menu_args+=("Download binary" b "new-window \"$CURRENT_DIR/install-wizard.sh download-binary\"")
+fi
+
+if [[ "$PLATFORM" == "Darwin" ]]; then
+  menu_args+=("Install with brew" w "new-window \"$CURRENT_DIR/install-wizard.sh install-with-brew\"")
+fi
+
+menu_args+=(
+  "Build from source (crystal required)" s "new-window \"$CURRENT_DIR/install-wizard.sh install-from-source\""
+  ""
   "Exit" q ""
+)
+
+tmux display-menu "${menu_args[@]}"


### PR DESCRIPTION
This PR fixes #167.

I tried this on my own fork and it seems like it works well! For example, see this github action run for the binary creation:
https://github.com/canova/tmux-fingers/actions/runs/23988887185
(ignore the homebrew failure as it's expected)

And this is the test release that I published:
https://github.com/canova/tmux-fingers/releases/tag/2.6.3

You can see that the macOS binary is there now.

Also I updated the install wizard to include binary installation option. Used my own fork to see if works, and I can validate that it does. It successfully downloads the binary and the plugin becomes usable.

This is the otool output, as you can see, only 2 shared libraries are there (since it's long, putting it inside a gist. Search for `LC_LOAD_DYLIB` for the important part):
https://gist.github.com/canova/586b9ead5992272b22a5b57200f6ea1f

This is the new updated tmux menu for macOS:
<img width="1728" height="970" alt="Screenshot 2026-04-05 at 00 43 24" src="https://github.com/user-attachments/assets/96259766-f553-41ce-83aa-328444835db2" />


Let me know what you think!

