### PR TITLE
Allow comma-separated values in @fingers-enabled-builtin-patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.7.0 - 31 May 2026
+
+* improved performance: ~30% faster
+* added macOS arm64 binary to the release/download pipeline
+* added kubernetes-pod builtin pattern for pod names
+* fixed clipboard integration in WSL
+* fixed various styling rendering issues related to submatches and backdrop
+* removed tput dependency
+* improved error handling
+* refactored option parsing, now with stricter validation
+* updated to crystal 1.19
+
 ## 2.6.2 - 15 Feb 2026
 
 * Fix line jumping and backdrop-style rendering issues related with tabs,

--- a/src/fingers/options.cr
+++ b/src/fingers/options.cr
@@ -13,7 +13,7 @@ define_bool_option :skip_wizard, false
 
 define_enum_option :hint_position, %w(left right), "left"
 define_enum_option :keyboard_layout, Fingers::ALPHABET_MAP.keys, "qwerty"
-define_enum_option :enabled_builtin_patterns, ["all", *Fingers::BUILTIN_PATTERNS.keys], "all"
+define_multi_enum_option :enabled_builtin_patterns, ["all", *Fingers::BUILTIN_PATTERNS.keys], "all"
 
 define_action_option :main, ":copy:"
 define_action_option :ctrl, ":open:"

--- a/src/fingers/options/macros.cr
+++ b/src/fingers/options/macros.cr
@@ -76,6 +76,20 @@ macro define_enum_option(name, possible_values, default)
   end
 end
 
+macro define_multi_enum_option(name, possible_values, default)
+  module Fingers::Options
+    class {{name.camelcase.id}} < Base
+      include ::Fingers::Options::Parsers::MultiEnumParser
+      DEFAULT = {{ default }}
+      alias Type = String
+
+      def possible_values
+        {{ possible_values }}
+      end
+    end
+  end
+end
+
 macro define_key_option(name, default)
   module Fingers::Options
     class {{name.camelcase.id}} < Base

--- a/src/fingers/options/parsers/multi_enum_parser.cr
+++ b/src/fingers/options/parsers/multi_enum_parser.cr
@@ -1,0 +1,19 @@
+module Fingers::Options::Parsers::MultiEnumParser
+  def valid?(value : String) : Tuple(Bool, String)
+    invalid = value.split(",").reject { |name| possible_values_as_strings.includes?(name) }
+
+    if invalid.empty?
+      { true, "ok" }
+    else
+      { false, "Invalid value(s) '#{invalid.join(",")}'. Possible values are: #{possible_values.join(", ")}" }
+    end
+  end
+
+  def possible_values
+    [] of String
+  end
+
+  def possible_values_as_strings
+    possible_values.map { |value| value.to_s }
+  end
+end


### PR DESCRIPTION
Fixes #176.

`@fingers-enabled-builtin-patterns` is documented as a comma-separated list, and `add_builtin_patterns` already splits the value on `,`. But it was declared with `define_enum_option`, whose parser validates the whole string as a single member — so any list of more than one pattern failed `load-config`, making the subset-selection use case from #19 impossible.

### Change

- Add `MultiEnumParser`: splits the value on `,`, validates each token against the allowed values, and reports any invalid names in the existing error format.
- Add a `define_multi_enum_option` macro that wires that parser in (otherwise identical to `define_enum_option`).
- Switch `enabled_builtin_patterns` to `define_multi_enum_option`.

This keeps per-value validation (a typo like `url,paht` still errors, now naming `paht`) while honoring the documented list semantics. `all` and single values are unaffected.

### Verification

Built with Crystal 1.19.1 and ran `load-config` against a scratch server:

| Value | Result |
|-------|--------|
| `all` | exit 0 |
| `url,path,ip,uuid,sha,hex,kubernetes` | exit 0 (was exit 1) |
| `url,bogus,path` | exit 1 — `Invalid value(s) 'bogus'. Possible values are: ...` |
