### PR TITLE
Fix CJK lines wrapping in the overlay (exact wide-char padding)

### DIFF
--- a/spec/lib/fingers/hinter_spec.cr
+++ b/spec/lib/fingers/hinter_spec.cr
@@ -110,6 +110,47 @@ Changes not staged for commit:
     hinter.run
   end
 
+  it "pads double-width (CJK) lines to the pane width without overflow" do
+    width = 20
+    output = TextOutput.new
+    patterns = Fingers::BUILTIN_PATTERNS.values.to_a
+    alphabet = "asdf".split("")
+
+    # 5 fullwidth katakana = 10 display columns; expect 10 trailing pad spaces
+    # so the rendered line is exactly `width` columns and never wraps.
+    input = ["アイウエオ"]
+
+    hinter = Fingers::Hinter.new(
+      input: input,
+      width: width,
+      patterns: patterns,
+      state: ::Fingers::State.new,
+      alphabet: alphabet,
+      output: output,
+    )
+
+    hinter.run
+
+    trailing_spaces = output.contents.size - output.contents.rstrip(' ').size
+    trailing_spaces.should eq(width - 10)
+  end
+
+  it "counts wide characters exactly via double_width_correction_for" do
+    output = TextOutput.new
+    hinter = Fingers::Hinter.new(
+      input: [""] of String,
+      width: 100,
+      patterns: Fingers::BUILTIN_PATTERNS.values.to_a,
+      state: ::Fingers::State.new,
+      alphabet: "asdf".split(""),
+      output: output,
+    )
+
+    hinter.double_width_correction_for("最終形:").should eq(3) # 3 CJK, 1 ASCII colon
+    hinter.double_width_correction_for("hello world").should eq(0)
+    hinter.double_width_correction_for("🦀 rust").should eq(1) # emoji stays wide
+  end
+
   it "can rerender when not reusing hints" do
     width = 100
     output = TextOutput.new

--- a/src/fingers/hinter.cr
+++ b/src/fingers/hinter.cr
@@ -84,10 +84,51 @@ module Fingers
       tab_correction = result.size - initial_length
 
       result = Fingers.config.backdrop_style + result
-      double_width_correction = ((line.bytesize - line.size) / 3).round.to_i
+      double_width_correction = double_width_correction_for(line)
       padding_amount = (width - line.size - double_width_correction - tab_correction)
       padding = padding_amount > 0 ? " " * padding_amount : ""
       output.print(result + padding + ending)
+    end
+
+    # Each double-width (East Asian Wide/Fullwidth, or emoji) character occupies
+    # two terminal columns but counts as a single character in `line.size`, so it
+    # needs +1 of padding correction. Counting wide characters directly is exact;
+    # the previous `(bytesize - size) / 3` heuristic was tuned for 4-byte emoji
+    # and under-counted 3-byte CJK characters, which over-padded the line, pushed
+    # it past the pane width, and made every CJK line wrap — leaving a blank row
+    # under it (see https://github.com/Morantron/tmux-fingers double-width report).
+    def double_width_correction_for(line)
+      line.each_char.count { |char| wide_char?(char) }
+    end
+
+    # True when `char` is rendered two columns wide by the terminal. Ranges follow
+    # the Unicode East Asian Width "Wide"/"Fullwidth" properties plus the common
+    # emoji blocks. Ambiguous-width symbols (e.g. box-drawing, powerline glyphs)
+    # are intentionally excluded: terminals render them one column wide.
+    def wide_char?(char : Char) : Bool
+      cp = char.ord
+      (0x1100 <= cp <= 0x115F) ||   # Hangul Jamo
+        (0x2329 <= cp <= 0x232A) || # angle brackets 〈 〉
+        (0x2E80 <= cp <= 0x303E) || # CJK radicals, Kangxi, CJK symbols
+        (0x3041 <= cp <= 0x33FF) || # Hiragana, Katakana, CJK symbols & punctuation
+        (0x3400 <= cp <= 0x4DBF) || # CJK Unified Ideographs Ext A
+        (0x4E00 <= cp <= 0x9FFF) || # CJK Unified Ideographs
+        (0xA000 <= cp <= 0xA4CF) || # Yi Syllables
+        (0xA960 <= cp <= 0xA97F) || # Hangul Jamo Ext A
+        (0xAC00 <= cp <= 0xD7A3) || # Hangul Syllables
+        (0xF900 <= cp <= 0xFAFF) || # CJK Compatibility Ideographs
+        (0xFE10 <= cp <= 0xFE19) || # Vertical forms
+        (0xFE30 <= cp <= 0xFE6F) || # CJK Compatibility Forms, Small Form Variants
+        (0xFF00 <= cp <= 0xFF60) || # Fullwidth Forms
+        (0xFFE0 <= cp <= 0xFFE6) || # Fullwidth signs
+        (0x1B000 <= cp <= 0x1B16F) || # Kana Supplement / Extended
+        (0x1F004 == cp) || (0x1F0CF == cp) || # Mahjong / playing-card joker
+        (0x1F18E == cp) || (0x1F191 <= cp <= 0x1F19A) ||
+        (0x1F200 <= cp <= 0x1F2FF) || # Enclosed CJK letters/months
+        (0x1F300 <= cp <= 0x1F64F) || # Misc symbols & pictographs, emoticons
+        (0x1F900 <= cp <= 0x1F9FF) || # Supplemental symbols & pictographs
+        (0x1FA00 <= cp <= 0x1FAFF) || # Symbols & pictographs Ext A
+        (0x20000 <= cp <= 0x3FFFD)    # CJK Unified Ideographs Ext B and beyond
     end
 
     def pattern : Regex

--- a/src/fingers/hinter.cr
+++ b/src/fingers/hinter.cr
@@ -96,7 +96,7 @@ module Fingers
     # the previous `(bytesize - size) / 3` heuristic was tuned for 4-byte emoji
     # and under-counted 3-byte CJK characters, which over-padded the line, pushed
     # it past the pane width, and made every CJK line wrap — leaving a blank row
-    # under it (see https://github.com/Morantron/tmux-fingers double-width report).
+    # beneath it in the overlay.
     def double_width_correction_for(line)
       line.each_char.count { |char| wide_char?(char) }
     end


### PR DESCRIPTION
## Problem

In panes containing CJK text, every line wraps in the fingers overlay, leaving a
blank row beneath it — the visible content appears to grow / become double-spaced
the moment fingers is triggered. ASCII-only lines are unaffected.

## Root cause

`Hinter#process_line` pads each rendered line to the pane width, correcting for
double-width characters with:

```crystal
double_width_correction = ((line.bytesize - line.size) / 3).round.to_i
```

This `/3` is tuned for 4-byte emoji (3 extra bytes → +1 column) but **under-counts
3-byte CJK characters**: a CJK char has `bytesize - size == 2`, so it contributes
`2/3 ≈ 0.67` instead of the `1` extra column it actually occupies.

The correction therefore comes out too small, `padding_amount` too large, and the
rendered line exceeds the pane width by ~`N/3` columns (N = CJK chars on the line).
The terminal wraps it, and the trailing `"\n"` then lands a row lower — so each
CJK line consumes two rows. Worked example at width 100:

| line | wide chars | rendered display width |
|---|---|---|
| `最終形:` | 3 | 101 → wraps |
| `- リンク開く → Shift+Cmd+Click …` | 16 | 105 → wraps |
| `* Crunched for 5s` (ASCII) | 0 | 100 → exact |

## Fix

Count wide characters exactly instead of estimating from byte length, using the
Unicode East Asian Width Wide/Fullwidth ranges plus the common emoji blocks.
Emoji remain wide, so they are unaffected; ambiguous-width symbols (box-drawing,
powerline glyphs) are deliberately excluded because terminals render them one
column wide.

## Tests

Adds specs covering CJK line padding (no overflow at the target width), exact
wide-char counting, and emoji non-regression. `crystal spec spec/lib/fingers/hinter_spec.cr`
passes (6 examples, 0 failures).
