### PR TITLE
Hint OSC 8 hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ NOTE: for changes to take effect, you'll need to source again your `.tmux.conf` 
 * [@fingers-keyboard-layout](#fingers-keyboard-layout)
 * [@fingers-show-copied-notification](#fingers-show-copied-notification)
 * [@fingers-enabled-builtin-patterns](#fingers-enabled-builtin-patterns)
+* [@fingers-hyperlinks](#fingers-hyperlinks)
 * [@fingers-use-system-clipboard](#fingers-use-system-clipboard)
 * [@fingers-enable-bindings](#fingers-enable-bindings)
 
@@ -284,6 +285,23 @@ A list of comma separated pattern names. Built-in patterns are the following:
 | git-status-branch | will match branch name in the output of git status        | `Your branch is up to date withname-of-branch` |
 | diff              | will match paths in diff output                           | `+++ a/path/to/file`                           |
 
+## @fingers-hyperlinks
+
+`default: 1`
+
+Hint [OSC 8 hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)
+as well as pattern matches. Programs such as `ls --hyperlink`, `gcc` or many
+test runners emit these: the terminal shows a piece of anchor text, and the URL
+travels alongside it invisibly.
+
+The hint is placed over the anchor text, and selecting it yields the URL, not
+the anchor. Since the two are unrelated, this reaches things no pattern can
+match, such as a bare filename that carries a `file://` URL.
+
+Set to `0` to disable. Note that a link wrapping the pane edge is highlighted up
+to the wrap point only, though the URL you get is still complete, and that an
+anchor too short to fit a hint is skipped.
+
 ## @fingers-use-system-clipboard
 
 `default: 1`
@@ -316,7 +334,7 @@ Arguments:
 
 Options:
         --mode              can be "jump" or "default" (default: default)
-        --patterns          comma separated list of pattern names
+        --patterns          comma separated list of pattern names, plus "hyperlink" to hint OSC 8 hyperlinks
         --main-action       command to which the output will be piped
         --ctrl-action       command to which the output will be piped when holding CTRL key
         --alt-action        command to which the output will be piped when holding ALT key

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ NOTE: for changes to take effect, you'll need to source again your `.tmux.conf` 
 * [@fingers-backdrop-style](#fingers-backdrop-style)
 * [@fingers-selected-hint-style](#fingers-selected-hint-style)
 * [@fingers-selected-highlight-style](#fingers-selected-highlight-style)
+* [@fingers-hyperlink-hint-style](#fingers-hyperlink-hint-style)
+* [@fingers-hyperlink-highlight-style](#fingers-hyperlink-highlight-style)
+* [@fingers-hyperlink-selected-hint-style](#fingers-hyperlink-selected-hint-style)
+* [@fingers-hyperlink-selected-highlight-style](#fingers-hyperlink-selected-highlight-style)
 * [@fingers-hint-position](#fingers-hint-position)
 * [@fingers-keyboard-layout](#fingers-keyboard-layout)
 * [@fingers-show-copied-notification](#fingers-show-copied-notification)
@@ -224,6 +228,19 @@ Format for hints in selected matches in multimode.
 `default: "fg=blue"`
 
 Format for selected matches in multimode.
+
+## @fingers-hyperlink-hint-style
+## @fingers-hyperlink-highlight-style
+## @fingers-hyperlink-selected-hint-style
+## @fingers-hyperlink-selected-highlight-style
+
+`default: unset, follows the regular style`
+
+Separate styles for [hyperlink](#fingers-hyperlinks) hints, so they can be told
+apart from pattern matches.
+
+Each one falls back to its regular counterpart while unset.
+Same syntax as [@fingers-hint-style](#fingers-hint-style).
 
 ## @fingers-hint-position
 

--- a/spec/lib/fingers/hinter_spec.cr
+++ b/spec/lib/fingers/hinter_spec.cr
@@ -6,6 +6,12 @@ require "../../../src/fingers/config"
 
 record StateDouble, selected_hints : Array(String)
 
+# The hint assigned to a match depends on how huffman lays out the alphabet, so
+# tests ask for every target rather than guessing which hint landed where.
+def targets_of(hinter, alphabet)
+  alphabet.compact_map { |hint| hinter.lookup(hint) }
+end
+
 class TextOutput < ::Fingers::Printer
   def initialize
     @contents = ""
@@ -135,5 +141,109 @@ Changes not staged for commit:
 
     hinter.run
     hinter.run
+  end
+
+  it "hints hyperlinks, yielding the url rather than the anchor" do
+    alphabet = "asdf".split("")
+
+    hinter = Fingers::Hinter.new(
+      input: ["see the docs for details"],
+      width: 100,
+      patterns: [] of String,
+      state: ::Fingers::State.new,
+      alphabet: alphabet,
+      output: TextOutput.new,
+      hyperlinks: [[Fingers::HyperlinkSpan.new(8, 4, "https://example.com/docs")]],
+    )
+
+    hinter.run
+
+    targets = targets_of(hinter, alphabet)
+
+    targets.size.should eq(1)
+    targets[0].text.should eq("https://example.com/docs")
+    targets[0].offset.should eq({0, 8})
+  end
+
+  it "lets the hyperlink win over a pattern covering the same cells" do
+    line = "visit https://example.com/page now"
+
+    hinter = Fingers::Hinter.new(
+      input: [line],
+      width: 100,
+      patterns: [Fingers::BUILTIN_PATTERNS["url"]],
+      state: ::Fingers::State.new,
+      alphabet: "asdf".split(""),
+      output: TextOutput.new,
+      hyperlinks: [[Fingers::HyperlinkSpan.new(6, 24, "https://example.com/elsewhere")]],
+    )
+
+    candidates = hinter.candidates_for(0)
+
+    candidates.size.should eq(1)
+    candidates[0].captured_text.should eq("https://example.com/elsewhere")
+  end
+
+  it "keeps patterns that sit outside any hyperlink" do
+    line = "0xFF and an anchor"
+
+    hinter = Fingers::Hinter.new(
+      input: [line],
+      width: 100,
+      patterns: [Fingers::BUILTIN_PATTERNS["hex"]],
+      state: ::Fingers::State.new,
+      alphabet: "asdf".split(""),
+      output: TextOutput.new,
+      hyperlinks: [[Fingers::HyperlinkSpan.new(12, 6, "https://example.com")]],
+    )
+
+    hinter.candidates_for(0).map(&.captured_text).should eq(["0xFF", "https://example.com"])
+  end
+
+  it "skips anchors too short to hold a hint" do
+    # Three matches over a two letter alphabet forces two character hints, which
+    # cannot fit over a single character anchor without shifting the columns
+    # of everything after it.
+    alphabet = "as".split("")
+
+    hinter = Fingers::Hinter.new(
+      input: ["x y z"],
+      width: 100,
+      patterns: [] of String,
+      state: ::Fingers::State.new,
+      alphabet: alphabet,
+      output: TextOutput.new,
+      hyperlinks: [[
+        Fingers::HyperlinkSpan.new(0, 1, "https://example.com/one"),
+        Fingers::HyperlinkSpan.new(2, 1, "https://example.com/two"),
+        Fingers::HyperlinkSpan.new(4, 1, "https://example.com/three"),
+      ]],
+    )
+
+    hinter.run
+
+    every_hint = alphabet + alphabet.flat_map { |a| alphabet.map { |b| a + b } }
+
+    targets_of(hinter, every_hint).should be_empty
+  end
+
+  it "renders the anchor rather than the url" do
+    output = TextOutput.new
+
+    hinter = Fingers::Hinter.new(
+      input: ["see the docs for details"],
+      width: 24,
+      patterns: [] of String,
+      state: ::Fingers::State.new,
+      alphabet: "asdf".split(""),
+      output: output,
+      hyperlinks: [[Fingers::HyperlinkSpan.new(8, 4, "https://example.com/docs")]],
+    )
+
+    hinter.run
+
+    output.contents.should_not contain("example.com")
+    output.contents.should contain("see the ")
+    output.contents.should contain(" for details")
   end
 end

--- a/spec/lib/fingers/hinter_spec.cr
+++ b/spec/lib/fingers/hinter_spec.cr
@@ -227,6 +227,35 @@ Changes not staged for commit:
     targets_of(hinter, every_hint).should be_empty
   end
 
+  it "styles hyperlinks with the hyperlink formatter" do
+    output = TextOutput.new
+
+    hinter = Fingers::Hinter.new(
+      input: ["0xFF and an anchor"],
+      width: 100,
+      patterns: [Fingers::BUILTIN_PATTERNS["hex"]],
+      state: ::Fingers::State.new,
+      alphabet: "asdf".split(""),
+      output: output,
+      formatter: ::Fingers::MatchFormatter.new(
+        hint_style: "<PATTERN-HINT>",
+        highlight_style: "<PATTERN-HL>",
+      ),
+      hyperlink_formatter: ::Fingers::MatchFormatter.new(
+        hint_style: "<LINK-HINT>",
+        highlight_style: "<LINK-HL>",
+      ),
+      hyperlinks: [[Fingers::HyperlinkSpan.new(12, 6, "https://example.com")]],
+    )
+
+    hinter.run
+
+    output.contents.should contain("<PATTERN-HINT>")
+    output.contents.should contain("<LINK-HINT>")
+    # the hint over the anchor is the hyperlink one, not the pattern one
+    output.contents.index("<LINK-HINT>").not_nil!.should be > output.contents.index("<PATTERN-HINT>").not_nil!
+  end
+
   it "renders the anchor rather than the url" do
     output = TextOutput.new
 

--- a/spec/lib/fingers/hyperlink_style_spec.cr
+++ b/spec/lib/fingers/hyperlink_style_spec.cr
@@ -1,0 +1,92 @@
+require "spec"
+require "../../spec_helper.cr"
+require "../../../src/fingers/match_formatter"
+require "../../../src/fingers/config"
+
+private def config_with(**overrides)
+  config = Fingers::Config.new
+
+  config.hint_style = "REGULAR-HINT"
+  config.highlight_style = "REGULAR-HL"
+  config.selected_hint_style = "REGULAR-SEL-HINT"
+  config.selected_highlight_style = "REGULAR-SEL-HL"
+
+  overrides.each do |key, value|
+    case key
+    when :hyperlink_hint_style               then config.hyperlink_hint_style = value
+    when :hyperlink_highlight_style          then config.hyperlink_highlight_style = value
+    when :hyperlink_selected_hint_style      then config.hyperlink_selected_hint_style = value
+    when :hyperlink_selected_highlight_style then config.hyperlink_selected_highlight_style = value
+    end
+  end
+
+  config
+end
+
+describe "hyperlink styles" do
+  it "falls back to the regular styles when unset" do
+    formatter = Fingers::MatchFormatter.for_hyperlinks(config_with)
+
+    formatter.format(hint: "a", highlight: "anchor", selected: false, offset: nil)
+      .should contain("REGULAR-HINT")
+    formatter.format(hint: "a", highlight: "anchor", selected: false, offset: nil)
+      .should contain("REGULAR-HL")
+    formatter.format(hint: "a", highlight: "anchor", selected: true, offset: nil)
+      .should contain("REGULAR-SEL-HINT")
+    formatter.format(hint: "a", highlight: "anchor", selected: true, offset: nil)
+      .should contain("REGULAR-SEL-HL")
+  end
+
+  it "keeps following the regular style when that one is customised" do
+    config = config_with
+    config.hint_style = "CUSTOMISED"
+
+    Fingers::MatchFormatter.for_hyperlinks(config)
+      .format(hint: "a", highlight: "anchor", selected: false, offset: nil)
+      .should contain("CUSTOMISED")
+  end
+
+  it "prefers the hyperlink style once set" do
+    config = config_with(
+      hyperlink_hint_style: "LINK-HINT",
+      hyperlink_highlight_style: "LINK-HL",
+    )
+
+    result = Fingers::MatchFormatter.for_hyperlinks(config)
+      .format(hint: "a", highlight: "anchor", selected: false, offset: nil)
+
+    result.should contain("LINK-HINT")
+    result.should contain("LINK-HL")
+    result.should_not contain("REGULAR-HINT")
+    result.should_not contain("REGULAR-HL")
+  end
+
+  it "resolves each style independently" do
+    config = config_with(hyperlink_hint_style: "LINK-HINT")
+
+    result = Fingers::MatchFormatter.for_hyperlinks(config)
+      .format(hint: "a", highlight: "anchor", selected: false, offset: nil)
+
+    result.should contain("LINK-HINT")
+    result.should contain("REGULAR-HL")
+  end
+
+  it "applies the selected variants only when selected" do
+    config = config_with(
+      hyperlink_hint_style: "LINK-HINT",
+      hyperlink_selected_hint_style: "LINK-SEL-HINT",
+      hyperlink_selected_highlight_style: "LINK-SEL-HL",
+    )
+
+    formatter = Fingers::MatchFormatter.for_hyperlinks(config)
+
+    unselected = formatter.format(hint: "a", highlight: "anchor", selected: false, offset: nil)
+    selected = formatter.format(hint: "a", highlight: "anchor", selected: true, offset: nil)
+
+    unselected.should contain("LINK-HINT")
+    unselected.should_not contain("LINK-SEL-HINT")
+
+    selected.should contain("LINK-SEL-HINT")
+    selected.should contain("LINK-SEL-HL")
+  end
+end

--- a/spec/lib/fingers/hyperlinks_spec.cr
+++ b/spec/lib/fingers/hyperlinks_spec.cr
@@ -1,0 +1,120 @@
+require "spec"
+require "../../spec_helper.cr"
+require "../../../src/fingers/hyperlinks"
+
+private def link(url, text)
+  "\e]8;;#{url}\e\\#{text}\e]8;;\e\\"
+end
+
+describe Fingers::Hyperlinks do
+  it "returns the line untouched when there is nothing to strip" do
+    text, spans = Fingers::Hyperlinks.parse_line("just some text")
+
+    text.should eq("just some text")
+    spans.should be_empty
+  end
+
+  it "strips the markers and locates the anchor" do
+    text, spans = Fingers::Hyperlinks.parse_line("a #{link("https://example.com", "Link")} b")
+
+    text.should eq("a Link b")
+    spans.size.should eq(1)
+    spans[0].start.should eq(2)
+    spans[0].size.should eq(4)
+    spans[0].url.should eq("https://example.com")
+  end
+
+  it "finds links opening at the start of the line" do
+    text, spans = Fingers::Hyperlinks.parse_line("#{link("https://example.com", "Link")} tail")
+
+    text.should eq("Link tail")
+    spans[0].start.should eq(0)
+    spans[0].size.should eq(4)
+  end
+
+  it "finds several links on the same line" do
+    line = "#{link("file:///tmp/one", "one")}\t#{link("file:///tmp/two", "two")} end"
+    text, spans = Fingers::Hyperlinks.parse_line(line)
+
+    text.should eq("one\ttwo end")
+    spans.map(&.url).should eq(["file:///tmp/one", "file:///tmp/two"])
+    spans.map(&.start).should eq([0, 4])
+    spans.map(&.size).should eq([3, 3])
+  end
+
+  it "counts characters rather than bytes so wide characters do not shift spans" do
+    text, spans = Fingers::Hyperlinks.parse_line("CJK: 你好 #{link("https://example.com", "Link")}")
+
+    text.should eq("CJK: 你好 Link")
+    spans[0].start.should eq(8)
+    spans[0].size.should eq(4)
+  end
+
+  it "handles links carrying an id parameter" do
+    line = "x \e]8;id=anchor3;https://example.com/n3\e\\anchor\e]8;;\e\\"
+    text, spans = Fingers::Hyperlinks.parse_line(line)
+
+    text.should eq("x anchor")
+    spans[0].url.should eq("https://example.com/n3")
+    spans[0].start.should eq(2)
+    spans[0].size.should eq(6)
+  end
+
+  it "skips colour changes nested inside the anchor" do
+    line = "\e[1m\e[31mRED\e[0m x \e]8;;https://example.com/id\e\\anchor\e[0m\e]8;;\e\\"
+    text, spans = Fingers::Hyperlinks.parse_line(line)
+
+    text.should eq("RED x anchor")
+    spans[0].start.should eq(6)
+    spans[0].size.should eq(6)
+  end
+
+  it "accepts BEL as a terminator" do
+    text, spans = Fingers::Hyperlinks.parse_line("\e]8;;https://example.com\aLink\e]8;;\a")
+
+    text.should eq("Link")
+    spans[0].url.should eq("https://example.com")
+    spans[0].size.should eq(4)
+  end
+
+  it "ignores unrelated OSC sequences" do
+    text, spans = Fingers::Hyperlinks.parse_line("\e]0;window title\atext")
+
+    text.should eq("text")
+    spans.should be_empty
+  end
+
+  it "closes a link left open at the end of the line" do
+    text, spans = Fingers::Hyperlinks.parse_line("x \e]8;;https://example.com/wrap\e\\wrapped-anchor")
+
+    text.should eq("x wrapped-anchor")
+    spans[0].start.should eq(2)
+    spans[0].size.should eq(14)
+    spans[0].url.should eq("https://example.com/wrap")
+  end
+
+  it "does not emit a span for a close without an open" do
+    text, spans = Fingers::Hyperlinks.parse_line("text\e]8;;\e\\")
+
+    text.should eq("text")
+    spans.should be_empty
+  end
+
+  it "makes progress on truncated escape sequences" do
+    text, spans = Fingers::Hyperlinks.parse_line("a\e")
+
+    text.should eq("a")
+    spans.should be_empty
+  end
+
+  it "parses a whole capture, keeping one entry per line" do
+    lines = ["plain", "a #{link("https://example.com", "Link")} b", "plain again"]
+    text, spans = Fingers::Hyperlinks.parse(lines)
+
+    text.should eq(["plain", "a Link b", "plain again"])
+    spans.size.should eq(3)
+    spans[0].should be_empty
+    spans[1].size.should eq(1)
+    spans[2].should be_empty
+  end
+end

--- a/src/fingers/commands/start.cr
+++ b/src/fingers/commands/start.cr
@@ -1,6 +1,7 @@
 require "cling"
 require "./base"
 require "../hinter"
+require "../hyperlinks"
 require "../view"
 require "../state"
 require "../input_socket"
@@ -26,6 +27,10 @@ module Fingers::Commands
   end
 
   class Start < Cling::Command
+    # Hyperlinks are not a regex, so they cannot live in the pattern table.
+    # They are selected by this reserved name instead.
+    HYPERLINK_PATTERN_NAME = "hyperlink"
+
     @original_options : Hash(String, String) = {} of String => String
     @last_key_table : String = "root"
     @last_pane_id : String | Nil
@@ -33,6 +38,7 @@ module Fingers::Commands
     @pane_id : String = ""
     @active_pane : Tmux::Pane | Nil
     @patterns : Array(String) = [] of String
+    @hyperlinks : Bool = false
     @main_action : String | Nil
     @ctrl_action : String | Nil
     @shift_action : String | Nil
@@ -49,7 +55,7 @@ module Fingers::Commands
                  default: "default"
 
       add_option "patterns",
-                 description: "comma separated list of pattern names",
+                 description: "comma separated list of pattern names, plus \"#{HYPERLINK_PATTERN_NAME}\" to hint OSC 8 hyperlinks",
                  type: :single
 
       add_option "main-action",
@@ -88,6 +94,7 @@ module Fingers::Commands
         @patterns = patterns_from_options(options.get("patterns").as_s)
       else
         @patterns = Fingers.config.patterns.values
+        @hyperlinks = Fingers.config.hyperlinks
       end
 
       @main_action = options.get?("main-action").try(&.as_s)
@@ -111,9 +118,15 @@ module Fingers::Commands
     private def patterns_from_options(pattern_names_option : String)
       pattern_names = pattern_names_option.split(",")
 
+      # An explicit list takes full control, so hyperlinks are on only when
+      # asked for by name.
+      @hyperlinks = pattern_names.includes?(HYPERLINK_PATTERN_NAME)
+
       result = [] of String
 
       pattern_names.each do |pattern_name|
+        next if pattern_name == HYPERLINK_PATTERN_NAME
+
         pattern = Fingers.config.patterns[pattern_name]?
         if pattern
           result << pattern
@@ -285,11 +298,33 @@ module Fingers::Commands
         state: state,
         output: pane_printer,
         reuse_hints: mode != "jump",
+        hyperlinks: hyperlink_spans,
       )
     end
 
     private getter pane_contents : Array(String) do
-      tmux.capture_pane(target_pane, join: mode != "jump").split("\n")
+      captured_pane[0]
+    end
+
+    private getter hyperlink_spans : Array(Array(Fingers::HyperlinkSpan)) do
+      captured_pane[1]
+    end
+
+    # Capturing with -e and stripping it back down keeps the text and the
+    # hyperlink positions consistent by construction, which a second capture
+    # would not.
+    private getter captured_pane : Tuple(Array(String), Array(Array(Fingers::HyperlinkSpan))) do
+      raw = tmux.capture_pane(
+        target_pane,
+        join: mode != "jump",
+        escapes: @hyperlinks,
+      ).split("\n")
+
+      if @hyperlinks
+        Fingers::Hyperlinks.parse(raw)
+      else
+        {raw, [] of Array(Fingers::HyperlinkSpan)}
+      end
     end
 
     private getter view : View do

--- a/src/fingers/hinter.cr
+++ b/src/fingers/hinter.cr
@@ -27,8 +27,9 @@ module Fingers
       property text : String
       property captured_text : String
       property capture_offset : Tuple(Int32, Int32) | Nil
+      property? hyperlink : Bool
 
-      def initialize(@start, @text, @captured_text, @capture_offset)
+      def initialize(@start, @text, @captured_text, @capture_offset, @hyperlink = false)
       end
 
       def size
@@ -44,6 +45,7 @@ module Fingers
     end
 
     @formatter : Formatter
+    @hyperlink_formatter : Formatter
     @patterns : Array(String)
     @alphabet : Array(String)
     @pattern : Regex | Nil
@@ -61,6 +63,7 @@ module Fingers
       alphabet = Fingers.config.alphabet,
       huffman = Huffman.new,
       formatter = ::Fingers::MatchFormatter.new,
+      hyperlink_formatter = ::Fingers::MatchFormatter.for_hyperlinks,
       reuse_hints = false,
       hyperlinks = [] of Array(HyperlinkSpan)
     )
@@ -71,6 +74,7 @@ module Fingers
       @state = state
       @output = output
       @formatter = formatter
+      @hyperlink_formatter = hyperlink_formatter
       @huffman = huffman
       @patterns = patterns
       @alphabet = alphabet
@@ -100,6 +104,7 @@ module Fingers
       :width,
       :state,
       :formatter,
+      :hyperlink_formatter,
       :huffman,
       :output,
       :patterns,
@@ -185,6 +190,7 @@ module Fingers
           text: line[span.start, span.size],
           captured_text: span.url,
           capture_offset: nil,
+          hyperlink: true,
         )
       end
 
@@ -250,12 +256,16 @@ module Fingers
         return text
       end
 
-      formatter.format(
+      formatter_for(candidate).format(
         hint: hint,
         highlight: text,
         selected: state.selected_hints.includes?(hint),
         offset: relative_capture_offset
       )
+    end
+
+    private def formatter_for(candidate : Candidate) : Formatter
+      candidate.hyperlink? ? hyperlink_formatter : formatter
     end
 
     def captured_text_for_match(match)

--- a/src/fingers/hinter.cr
+++ b/src/fingers/hinter.cr
@@ -1,5 +1,6 @@
 require "../huffman"
 require "./config"
+require "./hyperlinks"
 require "./match_formatter"
 require "./types"
 
@@ -14,6 +15,34 @@ module Fingers
   end
 
   class Hinter
+    EMPTY_HYPERLINKS = [] of HyperlinkSpan
+
+    # Something worth putting a hint on, wherever it came from.
+    #
+    # `text` is the range of the line that gets replaced, `captured_text` is what
+    # ends up being copied. They differ for hyperlinks, where the anchor is on
+    # screen but the url is what the user is after.
+    struct Candidate
+      property start : Int32
+      property text : String
+      property captured_text : String
+      property capture_offset : Tuple(Int32, Int32) | Nil
+
+      def initialize(@start, @text, @captured_text, @capture_offset)
+      end
+
+      def size
+        text.size
+      end
+
+      # How much room the hint has to overlay. For a pattern with a `match`
+      # group that is the group, otherwise the whole replaced range.
+      def hint_capacity
+        offset = capture_offset
+        offset ? offset[1] : text.size
+      end
+    end
+
     @formatter : Formatter
     @patterns : Array(String)
     @alphabet : Array(String)
@@ -21,6 +50,7 @@ module Fingers
     @hints : Array(String) | Nil
     @n_matches : Int32 | Nil
     @reuse_hints : Bool
+    @hyperlinks : Array(Array(HyperlinkSpan))
 
     def initialize(
       input : Array(String),
@@ -31,7 +61,8 @@ module Fingers
       alphabet = Fingers.config.alphabet,
       huffman = Huffman.new,
       formatter = ::Fingers::MatchFormatter.new,
-      reuse_hints = false
+      reuse_hints = false,
+      hyperlinks = [] of Array(HyperlinkSpan)
     )
       @lines = input
       @width = width
@@ -44,6 +75,7 @@ module Fingers
       @patterns = patterns
       @alphabet = alphabet
       @reuse_hints = reuse_hints
+      @hyperlinks = hyperlinks
     end
 
     def run
@@ -78,7 +110,7 @@ module Fingers
 
     def process_line(line, line_index, ending)
       tab_positions = tab_positions_for(line)
-      result = line.gsub(pattern) { |_m| replace($~, line_index) }
+      result = rebuild_line(line, line_index)
       initial_length = result.size
       result = expand_tabs(result, tab_positions)
       tab_correction = result.size - initial_length
@@ -108,21 +140,106 @@ module Fingers
       @target_by_text.clear
     end
 
-    def replace(match, line_index)
-      text = match[0]
+    # Splices the formatted hints into the line. Candidates never overlap, so a
+    # single left to right pass is enough.
+    def rebuild_line(line, line_index)
+      candidates = candidates_for(line_index)
 
+      return line if candidates.empty?
+
+      result = String::Builder.new(line.bytesize)
+      cursor = 0
+
+      candidates.each do |candidate|
+        next if candidate.start < cursor
+
+        result << line[cursor...candidate.start]
+        result << replace(candidate, line_index)
+
+        cursor = candidate.start + candidate.size
+      end
+
+      result << line[cursor..]
+
+      result.to_s
+    end
+
+    def candidates_for(line_index) : Array(Candidate)
+      candidates_by_line[line_index]
+    end
+
+    # Candidates depend only on the captured lines, so they survive the
+    # rerendering that happens on every keystroke.
+    getter candidates_by_line : Array(Array(Candidate)) do
+      Array(Array(Candidate)).new(lines.size) { |index| collect_candidates(index) }
+    end
+
+    private def collect_candidates(line_index) : Array(Candidate)
+      line = lines[line_index]
+
+      hyperlinks = hyperlinks_for(line_index).compact_map do |span|
+        next if span.size <= 0
+
+        Candidate.new(
+          start: span.start,
+          text: line[span.start, span.size],
+          captured_text: span.url,
+          capture_offset: nil,
+        )
+      end
+
+      result = hyperlinks.dup
+
+      # An empty pattern list would compile to a regex matching everywhere,
+      # which is what `--patterns hyperlink` on its own leaves us with.
+      unless patterns.empty?
+        line.scan(pattern) do |match|
+          candidate = candidate_from_match(match)
+
+          # A hyperlinked url matches the url pattern too. Hinting it twice
+          # would put two hints on the same cells, so the hyperlink wins.
+          next if hyperlinks.any? { |hyperlink| overlap?(hyperlink, candidate) }
+
+          result << candidate
+        end
+      end
+
+      result.sort_by!(&.start)
+    end
+
+    private def candidate_from_match(match : Regex::MatchData) : Candidate
       captured_text = captured_text_for_match(match)
-      relative_capture_offset = relative_capture_offset_for_match(match, captured_text)
+
+      Candidate.new(
+        start: match.begin(0),
+        text: match[0],
+        captured_text: captured_text,
+        capture_offset: relative_capture_offset_for_match(match, captured_text),
+      )
+    end
+
+    private def overlap?(a : Candidate, b : Candidate)
+      a.start < b.start + b.size && b.start < a.start + a.size
+    end
+
+    private def hyperlinks_for(line_index) : Array(HyperlinkSpan)
+      @hyperlinks[line_index]? || EMPTY_HYPERLINKS
+    end
+
+    def replace(candidate : Candidate, line_index)
+      text = candidate.text
+      captured_text = candidate.captured_text
+      relative_capture_offset = candidate.capture_offset
 
       absolute_offset = {
         line_index,
-        match.begin(0) + (relative_capture_offset ? relative_capture_offset[0] : 0)
+        candidate.start + (relative_capture_offset ? relative_capture_offset[0] : 0)
       }
 
       hint = hint_for_text(captured_text)
 
       # hint is longer than highlighted text, put it back in hint stack
-      if hint.size > captured_text.size
+      if hint.size > candidate.hint_capacity
         hints.push(hint)
         return text
       end
@@ -209,27 +326,15 @@ module Fingers
     def count_unique_matches
       match_set = Set(String).new
 
-      lines.each do |line|
-        line.scan(pattern) do |match|
-          match_set.add(captured_text_for_match(match))
-        end
+      candidates_by_line.each do |candidates|
+        candidates.each { |candidate| match_set.add(candidate.captured_text) }
       end
-
-      @n_matches = match_set.size
 
       match_set.size
     end
 
     def count_matches
-      result = 0
-
-      lines.each do |line|
-        line.scan(pattern) do |match|
-          result += 1
-        end
-      end
-
-      result
+      candidates_by_line.sum(&.size)
     end
 
     def tab_positions_for(line)

--- a/src/fingers/hyperlinks.cr
+++ b/src/fingers/hyperlinks.cr
@@ -1,0 +1,171 @@
+module Fingers
+  # Position of an OSC 8 hyperlink within a captured line.
+  #
+  # `start` and `size` are character indices into the stripped line rather than
+  # display columns, since that is the coordinate space the hinter splices into.
+  struct HyperlinkSpan
+    property start : Int32
+    property size : Int32
+    property url : String
+
+    def initialize(@start, @size, @url)
+    end
+  end
+
+  # Parses the output of `capture-pane -e`, returning both the text a plain
+  # capture would have produced and the position of every hyperlink in it.
+  #
+  # Stripping and locating in a single pass is what keeps the two consistent:
+  # positions are counted off the very characters that end up in the output, so
+  # they cannot drift the way they would when correlating two separate captures.
+  module Hyperlinks
+    extend self
+
+    ESC = '\e'
+    BEL = '\a'
+
+    def parse(lines : Array(String)) : Tuple(Array(String), Array(Array(HyperlinkSpan)))
+      text = Array(String).new(lines.size)
+      spans = Array(Array(HyperlinkSpan)).new(lines.size)
+
+      lines.each do |line|
+        line_text, line_spans = parse_line(line)
+        text << line_text
+        spans << line_spans
+      end
+
+      {text, spans}
+    end
+
+    def parse_line(line : String) : Tuple(String, Array(HyperlinkSpan))
+      spans = [] of HyperlinkSpan
+
+      return {line, spans} unless line.includes?(ESC)
+
+      chars = line.chars
+      text = String::Builder.new(line.bytesize)
+      col = 0
+      index = 0
+      open_at : Int32 | Nil = nil
+      open_url = ""
+
+      while index < chars.size
+        char = chars[index]
+
+        if char != ESC
+          text << char
+          col += 1
+          index += 1
+          next
+        end
+
+        consumed, url = read_escape(chars, index)
+        index += consumed
+
+        next if url.nil?
+
+        if url.empty?
+          start = open_at
+          next if start.nil?
+
+          spans << HyperlinkSpan.new(start, col - start, open_url)
+          open_at = nil
+          open_url = ""
+        else
+          open_at = col
+          open_url = url
+        end
+      end
+
+      # tmux closes a link at the pane edge and does not reopen it on the
+      # continuation row, so a link may still be open here. Its first segment is
+      # all we get, but the url is complete.
+      start = open_at
+      spans << HyperlinkSpan.new(start, col - start, open_url) unless start.nil?
+
+      {text.to_s, spans}
+    end
+
+    # Returns how many characters the escape sequence at `index` occupies, along
+    # with its url when it is an OSC 8 sequence. A closing OSC 8 is an opening
+    # one with an empty url, there is no distinct terminator token.
+    private def read_escape(chars, index) : Tuple(Int32, String | Nil)
+      case chars[index + 1]?
+      when nil
+        {1, nil}
+      when ']'
+        read_osc(chars, index)
+      when '['
+        {read_csi(chars, index), nil}
+      when 'P', 'X', '^', '_'
+        # DCS, SOS, PM and APC are string sequences, terminated like OSC
+        _, following = read_string_sequence(chars, index + 2)
+        {following - index, nil}
+      else
+        {2, nil}
+      end
+    end
+
+    private def read_osc(chars, index) : Tuple(Int32, String | Nil)
+      cursor = index + 2
+      command = String::Builder.new
+
+      while cursor < chars.size && chars[cursor] != ';'
+        command << chars[cursor]
+        cursor += 1
+      end
+
+      payload_end, following = read_string_sequence(chars, cursor)
+
+      return {following - index, nil} unless command.to_s == "8"
+
+      # The payload is `params ; url`, and params are non-empty whenever the
+      # emitter supplies an id, so the separator cannot be assumed to sit at the
+      # front of the payload.
+      params_end = cursor + 1
+
+      while params_end < payload_end && chars[params_end] != ';'
+        params_end += 1
+      end
+
+      return {following - index, nil} if params_end >= payload_end
+
+      {following - index, chars[(params_end + 1)...payload_end].join}
+    end
+
+    # Scans to the string terminator, returning where the payload ends and where
+    # the whole sequence ends. An unterminated sequence swallows the rest of the
+    # line, which at least guarantees progress.
+    private def read_string_sequence(chars, from) : Tuple(Int32, Int32)
+      index = from
+
+      while index < chars.size
+        char = chars[index]
+
+        return {index, index + 1} if char == BEL
+        return {index, index + 2} if char == ESC && chars[index + 1]? == '\\'
+
+        index += 1
+      end
+
+      {chars.size, chars.size}
+    end
+
+    # Parameter bytes, then intermediate bytes, then a single final byte.
+    private def read_csi(chars, index) : Int32
+      cursor = index + 2
+
+      while cursor < chars.size && chars[cursor].ord >= 0x30 && chars[cursor].ord <= 0x3f
+        cursor += 1
+      end
+
+      while cursor < chars.size && chars[cursor].ord >= 0x20 && chars[cursor].ord <= 0x2f
+        cursor += 1
+      end
+
+      cursor += 1 if cursor < chars.size
+
+      cursor - index
+    end
+  end
+end

--- a/src/fingers/match_formatter.cr
+++ b/src/fingers/match_formatter.cr
@@ -3,6 +3,19 @@ require "./types"
 
 module Fingers
   class MatchFormatter < Fingers::Formatter
+    # Styles hyperlinks, which are worth telling apart from pattern matches
+    # since the hint sits on anchor text that says nothing about the url behind
+    # it. Each style falls back to its regular counterpart when left unset, so
+    # customising only the regular one still styles both.
+    def self.for_hyperlinks(config = Fingers.config)
+      new(
+        hint_style: config.hyperlink_hint_style.presence || config.hint_style,
+        highlight_style: config.hyperlink_highlight_style.presence || config.highlight_style,
+        selected_hint_style: config.hyperlink_selected_hint_style.presence || config.selected_hint_style,
+        selected_highlight_style: config.hyperlink_selected_highlight_style.presence || config.selected_highlight_style,
+      )
+    end
+
     def initialize(
       hint_style : String = Fingers.config.hint_style,
       highlight_style : String = Fingers.config.highlight_style,

--- a/src/fingers/options.cr
+++ b/src/fingers/options.cr
@@ -10,6 +10,7 @@ define_bool_option :enable_bindings, true
 define_bool_option :benchmark_mode, false
 define_bool_option :show_copied_notification, true
 define_bool_option :skip_wizard, false
+define_bool_option :hyperlinks, true
 
 define_enum_option :hint_position, %w(left right), "left"
 define_enum_option :keyboard_layout, Fingers::ALPHABET_MAP.keys, "qwerty"

--- a/src/fingers/options.cr
+++ b/src/fingers/options.cr
@@ -27,6 +27,13 @@ define_style_option :selected_hint, Tmux.style_printer.print("fg=blue,bold")
 define_style_option :selected_highlight, Tmux.style_printer.print("fg=blue")
 define_style_option :backdrop, ""
 
+# Empty means "follow the regular style", resolved at render time so that
+# customising the regular one keeps both in step.
+define_style_option :hyperlink_hint, ""
+define_style_option :hyperlink_highlight, ""
+define_style_option :hyperlink_selected_hint, ""
+define_style_option :hyperlink_selected_highlight, ""
+
 define_string_option :tmux_version, ""
 
 define_fingers_macros

--- a/src/tmux.cr
+++ b/src/tmux.cr
@@ -161,15 +161,17 @@ class Tmux
     Pane.from_json(output)
   end
 
-  def capture_pane(pane : Pane, join = true)
+  def capture_pane(pane : Pane, join = true, escapes = false)
+    flags = "#{join ? "-J" : ""}#{escapes ? " -e" : ""}"
+
     if pane.pane_in_mode && !pane.scroll_position.nil?
       scroll_position = pane.scroll_position.not_nil!
       start_line = -scroll_position.to_i
       end_line = pane.pane_height.to_i - scroll_position.to_i - 1
 
-      exec("capture-pane #{join ? "-J" : ""} -p -t '#{pane.pane_id}' -S #{start_line} -E #{end_line}").chomp
+      exec("capture-pane #{flags} -p -t '#{pane.pane_id}' -S #{start_line} -E #{end_line}").chomp
     else
-      exec("capture-pane #{join ? "-J" : ""} -p -t '#{pane.pane_id}'").chomp
+      exec("capture-pane #{flags} -p -t '#{pane.pane_id}'").chomp
     end
   end
 


### PR DESCRIPTION
Hints [OSC 8 hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda). Programs such as `ls --hyperlink`, `gcc` or many test runners emit these: the terminal shows a piece of anchor text, and the URL travels alongside it invisibly.

The hint is placed over the anchor text, and selecting it yields the URL, not the anchor. Since the two are unrelated, this reaches things no pattern can match, such as a bare filename that carries a `file://` URL.

## How

Capture a pane with `-e` and strip it in one pass. tmux marks where each link opens and closes at the exact cell, so positions come free, and counting off the same characters that end up in the output keeps text and offsets consistent without any display-width arithmetic. Verified byte-for-byte that stripping `-e` reproduces the plain capture.

`Hinter` was driven by `line.gsub(pattern)`, which made the matched text simultaneously the thing highlighted and the thing copied. `Candidate` separates the replaced range from the payload, so patterns and hyperlinks share one splice. A hyperlinked URL also matches the `url` pattern, so hyperlinks win on overlap. `View`, `ActionRunner` and the `Formatter` interface are untouched.

## Options

| option | default |
|---|---|
| `@fingers-hyperlinks` | `1` |
| `@fingers-hyperlink-{hint,highlight,selected-hint,selected-highlight}-style` | follows the non-hyperlink style |

Also `--patterns hyperlink`, e.g. `--patterns hyperlink --main-action :open:`.

## Limitations

- Links wrapping the pane edge highlight the first segment only, since tmux closes them at the edge and doesn't reopen. The URL is still complete.
- Anchors too short for a hint are skipped rather than shifting columns.
- Offsets are character indices, so jump mode drifts on wide chars/tabs. Pre-existing; patterns use `match.begin(0)` and drift identically.
- No version gate needed: older tmux emits no OSC 8 under `-e`, so nothing changes.

## Testing

28 to 52 examples, all passing (13 parser, 6 hinter, 5 style). Verified against live tmux 3.7b and 3.5a in default mode, jump mode and copy-mode scrollback.

Benchmark, 300x300 pane, 50 runs: **18.88ms vs 18.56ms** on a screen with no hyperlinks (inside master's own stddev), **30.33ms vs 18.06ms** on a synthetic 1,700-link screen.

<details>
<summary>Aside: <code>dev/benchmark.cr</code> doesn't measure the configured screen</summary>

`benchmark_mode` exits before `teardown`, so the pane swap is never undone and `%0` ends up in the 80x24 `[fingers]` window. `kill-windows.sh` skips it (`grep -v ":%0:"` matches that window's own entry). Every run after the first measures 80x24 with ~7 lines, not 300x300 with 100.

`new-session -x 300 -y 300` fixes it, because new windows inherit the session size. The numbers above use that fix. Can send separately if useful.
</details>
